### PR TITLE
fix: Fix ontology API issues #21 and #22

### DIFF
--- a/src/pltr/commands/ontology.py
+++ b/src/pltr/commands/ontology.py
@@ -33,16 +33,13 @@ def list_ontologies(
     output: Optional[str] = typer.Option(
         None, "--output", "-o", help="Output file path"
     ),
-    page_size: Optional[int] = typer.Option(
-        None, "--page-size", help="Number of results per page"
-    ),
 ):
     """List all available ontologies."""
     try:
         service = OntologyService(profile=profile)
 
         with SpinnerProgressTracker().track_spinner("Fetching ontologies..."):
-            ontologies = service.list_ontologies(page_size=page_size)
+            ontologies = service.list_ontologies()
 
         formatter.format_table(
             ontologies,
@@ -106,16 +103,13 @@ def list_object_types(
     output: Optional[str] = typer.Option(
         None, "--output", "-o", help="Output file path"
     ),
-    page_size: Optional[int] = typer.Option(
-        None, "--page-size", help="Number of results per page"
-    ),
 ):
     """List object types in an ontology."""
     try:
         service = ObjectTypeService(profile=profile)
 
         with SpinnerProgressTracker().track_spinner("Fetching object types..."):
-            object_types = service.list_object_types(ontology_rid, page_size=page_size)
+            object_types = service.list_object_types(ontology_rid)
 
         formatter.format_table(
             object_types,

--- a/src/pltr/services/ontology.py
+++ b/src/pltr/services/ontology.py
@@ -18,15 +18,17 @@ class OntologyService(BaseService):
         List all ontologies visible to the current user.
 
         Args:
-            page_size: Number of results per page
+            page_size: Number of results per page (currently not supported by SDK)
 
         Returns:
             List of ontology information dictionaries
         """
         try:
-            result = self.service.Ontology.list(page_size=page_size)
+            # Note: page_size is not supported by the SDK's Ontology.list() method
+            result = self.service.Ontology.list()
             ontologies = []
-            for ontology in result:
+            # The response has a 'data' field containing the list of ontologies
+            for ontology in result.data:
                 ontologies.append(self._format_ontology_info(ontology))
             return ontologies
         except Exception as e:
@@ -73,15 +75,18 @@ class ObjectTypeService(BaseService):
 
         Args:
             ontology_rid: Ontology Resource Identifier
-            page_size: Number of results per page
+            page_size: Number of results per page (currently not supported by SDK)
 
         Returns:
             List of object type information dictionaries
         """
         try:
-            result = self.service.ObjectType.list(ontology_rid, page_size=page_size)
+            # ObjectType is nested under Ontology in the SDK
+            # Note: page_size is not supported by the SDK's list() method
+            result = self.service.Ontology.ObjectType.list(ontology_rid)
             object_types = []
-            for obj_type in result:
+            # The response has a 'data' field containing the list of object types
+            for obj_type in result.data:
                 object_types.append(self._format_object_type_info(obj_type))
             return object_types
         except Exception as e:
@@ -99,7 +104,8 @@ class ObjectTypeService(BaseService):
             Object type information dictionary
         """
         try:
-            obj_type = self.service.ObjectType.get(ontology_rid, object_type)
+            # ObjectType is nested under Ontology in the SDK
+            obj_type = self.service.Ontology.ObjectType.get(ontology_rid, object_type)
             return self._format_object_type_info(obj_type)
         except Exception as e:
             raise RuntimeError(f"Failed to get object type {object_type}: {e}")
@@ -113,17 +119,20 @@ class ObjectTypeService(BaseService):
         Args:
             ontology_rid: Ontology Resource Identifier
             object_type: Object type API name
-            page_size: Number of results per page
+            page_size: Number of results per page (currently not supported by SDK)
 
         Returns:
             List of link type information dictionaries
         """
         try:
-            result = self.service.ObjectType.list_outgoing_link_types(
-                ontology_rid, object_type, page_size=page_size
+            # ObjectType is nested under Ontology in the SDK
+            # Note: page_size is not supported by the SDK's list_outgoing_link_types() method
+            result = self.service.Ontology.ObjectType.list_outgoing_link_types(
+                ontology_rid, object_type
             )
             link_types = []
-            for link_type in result:
+            # The response has a 'data' field containing the list of link types
+            for link_type in result.data:
                 link_types.append(self._format_link_type_info(link_type))
             return link_types
         except Exception as e:

--- a/src/pltr/services/ontology.py
+++ b/src/pltr/services/ontology.py
@@ -13,18 +13,14 @@ class OntologyService(BaseService):
         """Get the Foundry ontologies service."""
         return self.client.ontologies
 
-    def list_ontologies(self, page_size: Optional[int] = None) -> List[Dict[str, Any]]:
+    def list_ontologies(self) -> List[Dict[str, Any]]:
         """
         List all ontologies visible to the current user.
-
-        Args:
-            page_size: Number of results per page (currently not supported by SDK)
 
         Returns:
             List of ontology information dictionaries
         """
         try:
-            # Note: page_size is not supported by the SDK's Ontology.list() method
             result = self.service.Ontology.list()
             ontologies = []
             # The response has a 'data' field containing the list of ontologies
@@ -67,22 +63,18 @@ class ObjectTypeService(BaseService):
         """Get the Foundry ontologies service."""
         return self.client.ontologies
 
-    def list_object_types(
-        self, ontology_rid: str, page_size: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+    def list_object_types(self, ontology_rid: str) -> List[Dict[str, Any]]:
         """
         List object types in an ontology.
 
         Args:
             ontology_rid: Ontology Resource Identifier
-            page_size: Number of results per page (currently not supported by SDK)
 
         Returns:
             List of object type information dictionaries
         """
         try:
             # ObjectType is nested under Ontology in the SDK
-            # Note: page_size is not supported by the SDK's list() method
             result = self.service.Ontology.ObjectType.list(ontology_rid)
             object_types = []
             # The response has a 'data' field containing the list of object types
@@ -111,7 +103,7 @@ class ObjectTypeService(BaseService):
             raise RuntimeError(f"Failed to get object type {object_type}: {e}")
 
     def list_outgoing_link_types(
-        self, ontology_rid: str, object_type: str, page_size: Optional[int] = None
+        self, ontology_rid: str, object_type: str
     ) -> List[Dict[str, Any]]:
         """
         List outgoing link types for an object type.
@@ -119,14 +111,12 @@ class ObjectTypeService(BaseService):
         Args:
             ontology_rid: Ontology Resource Identifier
             object_type: Object type API name
-            page_size: Number of results per page (currently not supported by SDK)
 
         Returns:
             List of link type information dictionaries
         """
         try:
             # ObjectType is nested under Ontology in the SDK
-            # Note: page_size is not supported by the SDK's list_outgoing_link_types() method
             result = self.service.Ontology.ObjectType.list_outgoing_link_types(
                 ontology_rid, object_type
             )

--- a/tests/test_services/test_ontology.py
+++ b/tests/test_services/test_ontology.py
@@ -38,8 +38,11 @@ def mock_object_type_service():
         # Set up client mock
         mock_client = Mock()
         mock_ontologies = Mock()
+        mock_ontology_class = Mock()
         mock_object_type_class = Mock()
-        mock_ontologies.ObjectType = mock_object_type_class
+        # ObjectType is nested under Ontology in the SDK
+        mock_ontology_class.ObjectType = mock_object_type_class
+        mock_ontologies.Ontology = mock_ontology_class
         mock_client.ontologies = mock_ontologies
         mock_auth.return_value.get_client.return_value = mock_client
 
@@ -187,7 +190,10 @@ def test_ontology_service_initialization():
 def test_list_ontologies(mock_ontology_service, sample_ontology):
     """Test listing ontologies."""
     service, mock_ontology_class = mock_ontology_service
-    mock_ontology_class.list.return_value = [sample_ontology]
+    # Mock the response with a 'data' field
+    mock_response = Mock()
+    mock_response.data = [sample_ontology]
+    mock_ontology_class.list.return_value = mock_response
 
     result = service.list_ontologies()
 
@@ -213,7 +219,10 @@ def test_get_ontology(mock_ontology_service, sample_ontology):
 def test_list_object_types(mock_object_type_service, sample_object_type):
     """Test listing object types."""
     service, mock_object_type_class = mock_object_type_service
-    mock_object_type_class.list.return_value = [sample_object_type]
+    # Mock the response with a 'data' field
+    mock_response = Mock()
+    mock_response.data = [sample_object_type]
+    mock_object_type_class.list.return_value = mock_response
 
     result = service.list_object_types("ri.ontology.main.ontology.test")
 

--- a/tests/test_services/test_ontology.py
+++ b/tests/test_services/test_ontology.py
@@ -229,7 +229,9 @@ def test_list_object_types(mock_object_type_service, sample_object_type):
     assert len(result) == 1
     assert result[0]["api_name"] == "Employee"
     assert result[0]["primary_key"] == "employee_id"
-    mock_object_type_class.list.assert_called_once()
+    mock_object_type_class.list.assert_called_once_with(
+        "ri.ontology.main.ontology.test"
+    )
 
 
 def test_get_object_type(mock_object_type_service, sample_object_type):


### PR DESCRIPTION
## Summary
- Fixes issue #21: Remove unsupported `page_size` parameter from `Ontology.list()` calls
- Fixes issue #22: Correct ObjectType API path to use `client.ontologies.Ontology.ObjectType` instead of `client.ontologies.ObjectType`
- Updates response handling to properly access the `data` field in list operation responses

## Changes
- Modified `src/pltr/services/ontology.py`:
  - Removed `page_size` parameter from SDK calls (not supported by current SDK version)
  - Fixed ObjectType API path to correctly nest under Ontology
  - Added proper response handling for list operations that return objects with a `data` field
- Updated `tests/test_services/test_ontology.py` to match the new API structure

## Test Plan
- [x] All ontology service tests pass (`uv run pytest tests/test_services/test_ontology.py`)
- [x] Full test suite passes (`uv run pytest tests/`)
- [x] Pre-commit hooks pass

Closes #21, #22