### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pltr-cli"
-version = "0.4.0"
+version = "0.5.0"
 description = "Command-line interface for Palantir Foundry APIs"
 authors = [
     { name = "anjor", email = "anjor@umd.edu" }


### PR DESCRIPTION
## Summary
- Bumped version from 0.4.0 to 0.5.0 in pyproject.toml
- Created release v0.5.0

## Related
- Release: https://github.com/anjor/pltr-cli/releases/tag/v0.5.0

## Changes
- Updated version number in pyproject.toml for the new release