### PR TITLE
Release v0.5.1: Deploy dataset upload functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pltr-cli"
-version = "0.5.0"
+version = "0.5.1"
 description = "Command-line interface for Palantir Foundry APIs"
 authors = [
     { name = "anjor", email = "anjor@umd.edu" }

--- a/uv.lock
+++ b/uv.lock
@@ -710,7 +710,7 @@ wheels = [
 
 [[package]]
 name = "pltr-cli"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click-repl" },


### PR DESCRIPTION
Deploy missing dataset upload and transaction commands to PyPI

## Changes
- Bumps version from 0.5.0 to 0.5.1
- Updates uv.lock file with new version

## Missing Commands Fixed
This release will deploy the dataset upload and transaction management commands that are currently missing from the PyPI package:

-  - Upload files to datasets
-  - Start transactions
-  - Commit transactions  
-  - Abort transactions
-  - Check transaction status

## Impact
Users will be able to create datasets and upload files using the complete workflow:
1. 
2. 
3. Or use transaction-based uploads for complex operations

Fixes the "No such command 'upload'" error reported by users.