### PR TITLE
feat: Add schema support for CSV uploads

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -710,7 +710,7 @@ wheels = [
 
 [[package]]
 name = "pltr-cli"
-version = "0.5.2"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click-repl" },


### PR DESCRIPTION
## Summary
- Adds schema management capabilities for datasets uploaded from CSV files
- Implements automatic type inference from CSV data
- Provides CLI commands for getting and setting dataset schemas

## Changes
- **DatasetService enhancements:**
  - Added `put_schema()` method to set dataset schemas using the SDK's put_schema API
  - Added `infer_schema_from_csv()` to automatically detect column types from CSV files
  - Supports types: STRING, INTEGER, DOUBLE, DATE, BOOLEAN, TIMESTAMP
  - Handles nullable fields based on presence of empty values

- **New CLI commands:**
  - `pltr dataset schema get <dataset_rid>` - View current dataset schema
  - `pltr dataset schema set <dataset_rid> --from-csv <file>` - Auto-infer schema from CSV
  - `pltr dataset schema set <dataset_rid> --json <schema>` - Set schema from JSON string
  - `pltr dataset schema set <dataset_rid> --json-file <file>` - Set schema from JSON file

- **Documentation updates:**
  - Added comprehensive schema management section to CSV upload examples
  - Included automatic inference and manual definition examples
  - Added troubleshooting section for common schema issues

## Motivation
Previously, CSV files uploaded to Foundry datasets didn't have proper schemas set, resulting in all columns being treated as strings. This made SQL queries less effective as type-specific operations (like AVG, SUM) wouldn't work correctly. This PR addresses issue mentioned in the CSV upload documentation by enabling users to set proper schemas after uploading CSV files.

## Test Plan
- [x] Tested schema inference with various CSV formats
- [x] Verified CLI commands work correctly
- [x] Confirmed type detection for INTEGER, DOUBLE, DATE, BOOLEAN, STRING
- [x] Tested nullable field detection
- [x] Documentation examples tested