### PR TITLE
Fix orchestration build command documentation and output formatting

### DIFF
--- a/src/pltr/commands/folder.py
+++ b/src/pltr/commands/folder.py
@@ -279,7 +279,7 @@ def _format_children_table(children: List[dict]):
     table = Table(title="Folder Children", show_header=True, header_style="bold cyan")
     table.add_column("Type", style="cyan")
     table.add_column("Display Name")
-    table.add_column("RID")
+    table.add_column("RID", no_wrap=True)
 
     for child in children:
         table.add_row(
@@ -296,8 +296,8 @@ def _format_folders_batch_table(folders: List[dict]):
     """Format multiple folders as a table."""
     table = Table(title="Folders", show_header=True, header_style="bold cyan")
     table.add_column("Display Name")
-    table.add_column("RID")
-    table.add_column("Parent Folder")
+    table.add_column("RID", no_wrap=True)
+    table.add_column("Parent Folder", no_wrap=True)
     table.add_column("Description")
 
     for folder in folders:

--- a/src/pltr/commands/orchestration.py
+++ b/src/pltr/commands/orchestration.py
@@ -92,7 +92,46 @@ def create_build(
         "table", "--format", "-f", help="Output format (table, json, csv)"
     ),
 ):
-    """Create a new build."""
+    """
+    Create a new build with specified target datasets.
+
+    The target parameter must be a JSON object with a 'type' field that specifies
+    the build strategy. Three types are supported:
+
+    \b
+    1. Manual Build - Explicitly specify datasets to build:
+       {
+         "type": "manual",
+         "targetRids": ["ri.foundry.main.dataset.abc123..."]
+       }
+
+    \b
+    2. Upstream Build - Build target datasets and all their upstream dependencies:
+       {
+         "type": "upstream",
+         "targetRids": ["ri.foundry.main.dataset.abc123..."],
+         "ignoredRids": []
+       }
+
+    \b
+    3. Connecting Build - Build datasets between input and target datasets:
+       {
+         "type": "connecting",
+         "inputRids": ["ri.foundry.main.dataset.input123..."],
+         "targetRids": ["ri.foundry.main.dataset.target123..."],
+         "ignoredRids": []
+       }
+
+    Examples:
+
+    \b
+      # Build specific datasets manually
+      pltr orchestration builds create '{"type": "manual", "targetRids": ["ri.foundry.main.dataset.abc123"]}' --branch master
+
+    \b
+      # Build dataset and all upstream dependencies
+      pltr orchestration builds create '{"type": "upstream", "targetRids": ["ri.foundry.main.dataset.abc123"], "ignoredRids": []}' --branch master --force
+    """
     try:
         service = OrchestrationService(profile=profile)
 

--- a/src/pltr/utils/formatting.py
+++ b/src/pltr/utils/formatting.py
@@ -64,7 +64,8 @@ class OutputFormatter:
                 f.write(json_str)
             return None
         else:
-            rich_print(json_str)
+            # Use plain print to ensure valid JSON output without ANSI codes
+            print(json_str)
             return json_str
 
     def _format_csv(
@@ -141,7 +142,11 @@ class OutputFormatter:
 
         # Add columns to table
         for column in columns:
-            table.add_column(column, overflow="fold")
+            # Don't truncate RID columns - they need full visibility
+            if "rid" in column.lower():
+                table.add_column(column, no_wrap=True, overflow="fold")
+            else:
+                table.add_column(column, overflow="fold")
 
         # Add rows
         for item in data:
@@ -424,7 +429,8 @@ class OutputFormatter:
         else:
             # For simple values, just print them
             if format_type == "json":
-                rich_print(json.dumps(data, indent=2, default=str))
+                # Use plain print to ensure valid JSON output without ANSI codes
+                print(json.dumps(data, indent=2, default=str))
             else:
                 rich_print(str(data))
 


### PR DESCRIPTION
## Summary

Fixes multiple usability issues reported in the orchestration build command that prevented users from creating builds via CLI.

## Issues Fixed

### 1. Build Target JSON Schema Documentation
**Problem**: Users received cryptic validation errors when trying to create builds because the required JSON schema wasn't documented.

**Solution**: Added comprehensive help documentation to the `pltr orchestration builds create` command showing:
- All three build target types: `manual`, `upstream`, and `connecting`
- Required fields for each type with the discriminator `type` field
- Working command examples

**Before**:
```
❌ Failed to create build: Unable to extract tag using discriminator 'type'
```

**After**: Clear documentation in `--help` showing exact JSON format needed.

### 2. JSON Output Format
**Problem**: `--format json` output included ANSI escape codes from rich_print(), making it unparseable.

**Solution**: Changed JSON output to use plain `print()` instead of `rich_print()`.

**Result**: Valid, parseable JSON that can be piped to `jq` or other tools.

### 3. RID Truncation in Tables
**Problem**: Dataset RIDs were truncated in table output (e.g., `ri.foundry.main.dataset.a…`), making it impossible to copy full RIDs needed for build commands.

**Solution**: 
- Added `no_wrap=True` to all RID columns in table formatters
- Auto-detect columns with "rid" in the name
- Fixed folder list and batch commands

**Result**: Full RIDs always visible and copyable.

## Testing

- ✅ Pre-commit hooks passed (ruff, mypy, bandit)
- ✅ Help documentation displays correctly with formatted examples
- ✅ JSON output is valid and parseable
- ✅ RID columns display full values in table output

## Examples

### New help documentation:
```bash
$ pltr orchestration builds create --help
```
Shows complete JSON schema with examples for all three build types.

### Valid JSON output:
```bash
$ pltr folder list ri.compass.main.folder.0 --format json | jq .
```
Now works correctly without JSON parse errors.

### Full RID display:
```bash
$ pltr folder list ri.compass.main.folder.0
```
Shows complete RIDs like `ri.foundry.main.dataset.abc123...` instead of truncated versions.

## Related Issues

Addresses the bug report from /tmp/claude/pltr_cli_error_report.md covering issues #1-6 from the report.