### PR TITLE
feat: Add count and search methods to ontology objects

### DIFF
--- a/src/pltr/services/ontology.py
+++ b/src/pltr/services/ontology.py
@@ -287,6 +287,77 @@ class OntologyObjectService(BaseService):
         except Exception as e:
             raise RuntimeError(f"Failed to list linked objects: {e}")
 
+    def count_objects(
+        self,
+        ontology_rid: str,
+        object_type: str,
+        branch: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Count objects of a specific type.
+
+        Args:
+            ontology_rid: Ontology Resource Identifier
+            object_type: Object type API name
+            branch: Branch name (optional)
+
+        Returns:
+            Dictionary containing count information
+        """
+        try:
+            count = self.service.OntologyObject.count(
+                ontology_rid,
+                object_type,
+                branch_name=branch,
+            )
+            return {
+                "ontology_rid": ontology_rid,
+                "object_type": object_type,
+                "count": count,
+                "branch": branch,
+            }
+        except Exception as e:
+            raise RuntimeError(f"Failed to count objects: {e}")
+
+    def search_objects(
+        self,
+        ontology_rid: str,
+        object_type: str,
+        query: str,
+        page_size: Optional[int] = None,
+        properties: Optional[List[str]] = None,
+        branch: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search objects by query.
+
+        Args:
+            ontology_rid: Ontology Resource Identifier
+            object_type: Object type API name
+            query: Search query string
+            page_size: Number of results per page
+            properties: List of properties to include
+            branch: Branch name (optional)
+
+        Returns:
+            List of matching object dictionaries
+        """
+        try:
+            result = self.service.OntologyObject.search(
+                ontology_rid,
+                object_type,
+                query=query,
+                page_size=page_size,
+                properties=properties,
+                branch_name=branch,
+            )
+            objects = []
+            for obj in result:
+                objects.append(self._format_object(obj))
+            return objects
+        except Exception as e:
+            raise RuntimeError(f"Failed to search objects: {e}")
+
     def _format_object(self, obj: Any) -> Dict[str, Any]:
         """Format object for consistent output."""
         # Objects may have various properties - extract them dynamically

--- a/tests/test_commands/test_ontology.py
+++ b/tests/test_commands/test_ontology.py
@@ -220,6 +220,111 @@ def test_list_linked_objects_command(mock_services):
     mock_instance.list_linked_objects.assert_called_once()
 
 
+def test_count_objects_command(mock_services):
+    """Test count objects command."""
+    mock_instance = Mock()
+    mock_instance.count_objects.return_value = {
+        "ontology_rid": "ri.ontology.main.ontology.test",
+        "object_type": "Employee",
+        "count": 42,
+        "branch": None,
+    }
+    mock_services["object"].return_value = mock_instance
+
+    result = runner.invoke(
+        app, ["object-count", "ri.ontology.main.ontology.test", "Employee"]
+    )
+
+    assert result.exit_code == 0
+    mock_instance.count_objects.assert_called_once_with(
+        "ri.ontology.main.ontology.test", "Employee", branch=None
+    )
+
+
+def test_count_objects_with_branch(mock_services):
+    """Test count objects with branch specified."""
+    mock_instance = Mock()
+    mock_instance.count_objects.return_value = {
+        "ontology_rid": "ri.ontology.main.ontology.test",
+        "object_type": "Employee",
+        "count": 24,
+        "branch": "master",
+    }
+    mock_services["object"].return_value = mock_instance
+
+    result = runner.invoke(
+        app,
+        [
+            "object-count",
+            "ri.ontology.main.ontology.test",
+            "Employee",
+            "--branch",
+            "master",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_instance.count_objects.assert_called_once_with(
+        "ri.ontology.main.ontology.test", "Employee", branch="master"
+    )
+
+
+def test_search_objects_command(mock_services):
+    """Test search objects command."""
+    mock_instance = Mock()
+    mock_instance.search_objects.return_value = [
+        {"employee_id": "EMP001", "name": "John Doe"}
+    ]
+    mock_services["object"].return_value = mock_instance
+
+    result = runner.invoke(
+        app,
+        [
+            "object-search",
+            "ri.ontology.main.ontology.test",
+            "Employee",
+            "--query",
+            "John",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_instance.search_objects.assert_called_once()
+
+
+def test_search_objects_with_options(mock_services):
+    """Test search objects with all options."""
+    mock_instance = Mock()
+    mock_instance.search_objects.return_value = [
+        {"employee_id": "EMP001", "name": "John Doe"}
+    ]
+    mock_services["object"].return_value = mock_instance
+
+    result = runner.invoke(
+        app,
+        [
+            "object-search",
+            "ri.ontology.main.ontology.test",
+            "Employee",
+            "--query",
+            "Jane",
+            "--page-size",
+            "10",
+            "--properties",
+            "name,department",
+            "--branch",
+            "master",
+        ],
+    )
+
+    assert result.exit_code == 0
+    call_args = mock_instance.search_objects.call_args
+    assert call_args[0] == ("ri.ontology.main.ontology.test", "Employee", "Jane")
+    assert call_args[1]["page_size"] == 10
+    assert call_args[1]["properties"] == ["name", "department"]
+    assert call_args[1]["branch"] == "master"
+
+
 # Action command tests
 def test_apply_action_command(mock_services):
     """Test apply action command."""

--- a/tests/test_services/test_ontology.py
+++ b/tests/test_services/test_ontology.py
@@ -335,6 +335,85 @@ def test_list_linked_objects(mock_ontology_object_service, sample_object):
     mock_ontology_object_class.list_linked_objects.assert_called_once()
 
 
+def test_count_objects(mock_ontology_object_service):
+    """Test counting objects."""
+    service, mock_ontology_object_class = mock_ontology_object_service
+    mock_ontology_object_class.count.return_value = 42
+
+    result = service.count_objects("ri.ontology.main.ontology.test", "Employee")
+
+    assert result["count"] == 42
+    assert result["ontology_rid"] == "ri.ontology.main.ontology.test"
+    assert result["object_type"] == "Employee"
+    assert result["branch"] is None
+    mock_ontology_object_class.count.assert_called_once_with(
+        "ri.ontology.main.ontology.test", "Employee", branch_name=None
+    )
+
+
+def test_count_objects_with_branch(mock_ontology_object_service):
+    """Test counting objects with branch specified."""
+    service, mock_ontology_object_class = mock_ontology_object_service
+    mock_ontology_object_class.count.return_value = 24
+
+    result = service.count_objects(
+        "ri.ontology.main.ontology.test", "Employee", branch="master"
+    )
+
+    assert result["count"] == 24
+    assert result["branch"] == "master"
+    mock_ontology_object_class.count.assert_called_once_with(
+        "ri.ontology.main.ontology.test", "Employee", branch_name="master"
+    )
+
+
+def test_search_objects(mock_ontology_object_service, sample_object):
+    """Test searching objects."""
+    service, mock_ontology_object_class = mock_ontology_object_service
+    mock_ontology_object_class.search.return_value = [sample_object]
+
+    result = service.search_objects(
+        "ri.ontology.main.ontology.test", "Employee", "John"
+    )
+
+    assert len(result) == 1
+    assert result[0]["employee_id"] == "EMP001"
+    assert result[0]["name"] == "John Doe"
+    mock_ontology_object_class.search.assert_called_once_with(
+        "ri.ontology.main.ontology.test",
+        "Employee",
+        query="John",
+        page_size=None,
+        properties=None,
+        branch_name=None,
+    )
+
+
+def test_search_objects_with_options(mock_ontology_object_service, sample_object):
+    """Test searching objects with all options."""
+    service, mock_ontology_object_class = mock_ontology_object_service
+    mock_ontology_object_class.search.return_value = [sample_object]
+
+    result = service.search_objects(
+        "ri.ontology.main.ontology.test",
+        "Employee",
+        "Jane",
+        page_size=10,
+        properties=["name", "department"],
+        branch="master",
+    )
+
+    assert len(result) == 1
+    mock_ontology_object_class.search.assert_called_once_with(
+        "ri.ontology.main.ontology.test",
+        "Employee",
+        query="Jane",
+        page_size=10,
+        properties=["name", "department"],
+        branch_name="master",
+    )
+
+
 # ActionService Tests
 def test_apply_action(mock_action_service, sample_action_result):
     """Test applying an action."""


### PR DESCRIPTION
## Summary
Implements the missing SDK functionality identified in issue #68 to enhance object discovery workflows in the ontology module.

This PR adds two convenience methods that were missing from the ontology module:
- **Object counting**: Count objects of a specific type
- **Object search**: Search for objects using query strings

## Changes Made

### Service Layer
- ✅ Added `count_objects()` method to `OntologyObjectService` with branch support
- ✅ Added `search_objects()` method to `OntologyObjectService` with full parameter support (page_size, properties, branch)

### CLI Commands
- ✅ Added `pltr ontology object-count <ontology_rid> <object_type> [--branch]`
- ✅ Added `pltr ontology object-search <ontology_rid> <object_type> --query <text> [--page-size] [--properties] [--branch]`

### Tests
- ✅ Added 4 new service-level unit tests (basic + with options)
- ✅ Added 4 new command-level unit tests (basic + with options)
- ✅ All 43 ontology-related tests passing

## Test Results
```
tests/test_services/test_ontology.py::test_count_objects PASSED
tests/test_services/test_ontology.py::test_count_objects_with_branch PASSED
tests/test_services/test_ontology.py::test_search_objects PASSED
tests/test_services/test_ontology.py::test_search_objects_with_options PASSED
tests/test_commands/test_ontology.py::test_count_objects_command PASSED
tests/test_commands/test_ontology.py::test_count_objects_with_branch PASSED
tests/test_commands/test_ontology.py::test_search_objects_command PASSED
tests/test_commands/test_ontology.py::test_search_objects_with_options PASSED

========== 43 passed, 1 skipped, 546 deselected, 2 warnings in 0.62s ===========
```

## Files Changed
- `src/pltr/services/ontology.py` (+71 lines)
- `src/pltr/commands/ontology.py` (+93 lines)
- `tests/test_services/test_ontology.py` (+79 lines)
- `tests/test_commands/test_ontology.py` (+105 lines)

**Total: 348 lines added**

## Example Usage

### Count objects
```bash
pltr ontology object-count ri.ontology.main.ontology.prod Employee
pltr ontology object-count ri.ontology.main.ontology.prod Employee --branch master
```

### Search objects
```bash
pltr ontology object-search ri.ontology.main.ontology.prod Employee --query "John"
pltr ontology object-search ri.ontology.main.ontology.prod Employee --query "Engineer" --properties "name,department" --page-size 10
```

Closes #68