### PR TITLE
fix: Use correct SDK method for file downloads

### DIFF
--- a/src/pltr/services/dataset.py
+++ b/src/pltr/services/dataset.py
@@ -487,18 +487,15 @@ class DatasetService(BaseService):
             # Ensure output directory exists
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            file_content = self.service.Dataset.File.read(
+            # Use Dataset.File.content() which returns bytes directly
+            # Note: In SDK v1.27.0, the method is 'content' not 'read'
+            file_content = self.service.Dataset.File.content(
                 dataset_rid=dataset_rid, file_path=file_path, branch_name=branch
             )
 
-            # Write file content to disk
+            # Write file content to disk (file_content is bytes)
             with open(output_path, "wb") as f:
-                if hasattr(file_content, "read"):
-                    # If it's a stream
-                    f.write(file_content.read())
-                else:
-                    # If it's bytes
-                    f.write(file_content)
+                f.write(file_content)
 
             return {
                 "dataset_rid": dataset_rid,


### PR DESCRIPTION
## Summary
- Fixed the `pltr dataset files get` command which was failing with `'FileClient' object has no attribute 'read'` error
- Updated to use the correct SDK method: `Dataset.File.content()` instead of `Dataset.File.read()`
- Simplified file download logic since `content()` returns bytes directly

## Root Cause
The foundry-platform-sdk v1.27.0 API changed from using `Dataset.File.read()` to `Dataset.File.content()`. The `content()` method returns bytes directly, making the previous stream handling code unnecessary and broken.

## Changes
- Changed `self.service.Dataset.File.read()` to `self.service.Dataset.File.content()`
- Removed complex stream handling logic since `content()` returns bytes directly
- Added comment explaining the SDK method change

## Test Plan
- [x] Tested file download with command: `pltr dataset files get <dataset-rid> <file-path> <output-path>`
- [x] Verified downloaded file integrity (1.7MB CSV file downloaded successfully)
- [x] Pre-commit hooks passed (linting, type checking, security checks)

## Before
```bash
$ pltr dataset files get ri.foundry.main.dataset.xxx file.csv /tmp/out.csv
❌ Failed to download file: 'FileClient' object has no attribute 'read'
```

## After
```bash
$ pltr dataset files get ri.foundry.main.dataset.xxx file.csv /tmp/out.csv
✅ File downloaded to /tmp/out.csv
ℹ️  Size: 1828952 bytes
```