### PR TITLE
feat: Add missing Admin module SDK functionality

### DIFF
--- a/tests/test_commands/test_admin.py
+++ b/tests/test_commands/test_admin.py
@@ -466,3 +466,388 @@ class TestAdminCommands:
         # Assert
         assert result.exit_code == 0
         mock_formatter_instance.display.assert_called_once_with(create_result, "csv")
+
+    # New User Commands Tests
+    def test_user_delete_command_with_confirm(self, runner, mock_service):
+        """Test user delete command with confirmation."""
+        # Setup
+        user_id = "user123"
+        delete_result = {
+            "success": True,
+            "message": f"User {user_id} deleted successfully",
+        }
+        mock_service.delete_user.return_value = delete_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["user", "delete", user_id, "--confirm"])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.delete_user.assert_called_once_with(user_id)
+
+    def test_user_delete_command_error(self, runner, mock_service):
+        """Test user delete command error handling."""
+        # Setup
+        user_id = "user123"
+        mock_service.delete_user.side_effect = RuntimeError("User not found")
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["user", "delete", user_id, "--confirm"])
+
+        # Assert
+        assert result.exit_code == 1
+        assert "Error:" in result.stdout
+
+    def test_user_batch_get_command_success(self, runner, mock_service):
+        """Test successful user batch get command."""
+        # Setup
+        batch_result = {
+            "data": [
+                {"id": "user1", "username": "john"},
+                {"id": "user2", "username": "jane"},
+            ]
+        }
+        mock_service.get_batch_users.return_value = batch_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["user", "batch-get", "user1", "user2"])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.get_batch_users.assert_called_once()
+
+    def test_user_batch_get_command_exceeds_limit(self, runner, mock_service):
+        """Test user batch get command exceeds limit error."""
+        # Setup
+        mock_service.get_batch_users.side_effect = ValueError(
+            "Maximum batch size is 500 users"
+        )
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["user", "batch-get", "user1"])
+
+        # Assert
+        assert result.exit_code == 1
+        assert "Error:" in result.stdout
+
+    # New Group Commands Tests
+    def test_group_batch_get_command_success(self, runner, mock_service):
+        """Test successful group batch get command."""
+        # Setup
+        batch_result = {
+            "data": [
+                {"id": "group1", "name": "Engineering"},
+                {"id": "group2", "name": "Product"},
+            ]
+        }
+        mock_service.get_batch_groups.return_value = batch_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["group", "batch-get", "group1", "group2"])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.get_batch_groups.assert_called_once()
+
+    # Marking Commands Tests
+    def test_marking_list_command_success(self, runner, mock_service):
+        """Test successful marking list command."""
+        # Setup
+        marking_result = {
+            "data": [
+                {"id": "marking1", "name": "Confidential"},
+                {"id": "marking2", "name": "Public"},
+            ],
+            "nextPageToken": None,
+        }
+        mock_service.list_markings.return_value = marking_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["marking", "list"])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.list_markings.assert_called_once_with(
+            page_size=None, page_token=None
+        )
+
+    def test_marking_list_with_pagination(self, runner, mock_service):
+        """Test marking list command with pagination."""
+        # Setup
+        marking_result = {"data": [], "nextPageToken": "next123"}
+        mock_service.list_markings.return_value = marking_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["marking", "list", "--page-size", "10", "--page-token", "prev123"]
+            )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.list_markings.assert_called_once_with(
+            page_size=10, page_token="prev123"
+        )
+
+    def test_marking_get_command_success(self, runner, mock_service):
+        """Test successful marking get command."""
+        # Setup
+        marking_id = "marking123"
+        marking_result = {
+            "id": marking_id,
+            "name": "Confidential",
+            "description": "Confidential data",
+        }
+        mock_service.get_marking.return_value = marking_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["marking", "get", marking_id])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.get_marking.assert_called_once_with(marking_id)
+
+    def test_marking_batch_get_command_success(self, runner, mock_service):
+        """Test successful marking batch get command."""
+        # Setup
+        batch_result = {
+            "data": [
+                {"id": "marking1", "name": "Confidential"},
+                {"id": "marking2", "name": "Public"},
+            ]
+        }
+        mock_service.get_batch_markings.return_value = batch_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["marking", "batch-get", "marking1", "marking2"]
+            )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.get_batch_markings.assert_called_once()
+
+    def test_marking_create_command_success(self, runner, mock_service):
+        """Test successful marking create command."""
+        # Setup
+        marking_name = "New Marking"
+        description = "Test description"
+        create_result = {
+            "id": "new_marking_id",
+            "name": marking_name,
+            "description": description,
+        }
+        mock_service.create_marking.return_value = create_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                ["marking", "create", marking_name, "--description", description],
+            )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.create_marking.assert_called_once_with(
+            name=marking_name, description=description, category_id=None
+        )
+
+    def test_marking_create_command_minimal(self, runner, mock_service):
+        """Test marking create command with minimal parameters."""
+        # Setup
+        marking_name = "Simple Marking"
+        create_result = {"id": "simple_marking_id", "name": marking_name}
+        mock_service.create_marking.return_value = create_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["marking", "create", marking_name])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.create_marking.assert_called_once_with(
+            name=marking_name, description=None, category_id=None
+        )
+
+    def test_marking_replace_command_with_confirm(self, runner, mock_service):
+        """Test marking replace command with confirmation."""
+        # Setup
+        marking_id = "marking123"
+        new_name = "Updated Marking"
+        replace_result = {
+            "id": marking_id,
+            "name": new_name,
+        }
+        mock_service.replace_marking.return_value = replace_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["marking", "replace", marking_id, new_name, "--confirm"]
+            )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.replace_marking.assert_called_once_with(
+            marking_id=marking_id, name=new_name, description=None
+        )
+
+    def test_marking_create_command_error(self, runner, mock_service):
+        """Test marking create command error handling."""
+        # Setup
+        mock_service.create_marking.side_effect = RuntimeError("Permission denied")
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["marking", "create", "Test Marking"])
+
+        # Assert
+        assert result.exit_code == 1
+        assert "Error:" in result.stdout
+
+    # New Organization Commands Tests
+    def test_org_create_command_success(self, runner, mock_service):
+        """Test successful organization create command."""
+        # Setup
+        org_name = "New Org"
+        enrollment_rid = "enrollment123"
+        create_result = {
+            "id": "new_org_id",
+            "name": org_name,
+        }
+        mock_service.create_organization.return_value = create_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                ["org", "create", org_name, "--enrollment-rid", enrollment_rid],
+            )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.create_organization.assert_called_once_with(
+            name=org_name, enrollment_rid=enrollment_rid, admin_ids=None
+        )
+
+    def test_org_create_command_with_admins(self, runner, mock_service):
+        """Test organization create command with admin IDs."""
+        # Setup
+        org_name = "New Org"
+        enrollment_rid = "enrollment123"
+        create_result = {
+            "id": "new_org_id",
+            "name": org_name,
+        }
+        mock_service.create_organization.return_value = create_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "org",
+                    "create",
+                    org_name,
+                    "--enrollment-rid",
+                    enrollment_rid,
+                    "--admin-id",
+                    "admin1",
+                    "--admin-id",
+                    "admin2",
+                ],
+            )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.create_organization.assert_called_once()
+
+    def test_org_replace_command_with_confirm(self, runner, mock_service):
+        """Test organization replace command with confirmation."""
+        # Setup
+        org_rid = "org123"
+        new_name = "Updated Org"
+        replace_result = {
+            "id": org_rid,
+            "name": new_name,
+        }
+        mock_service.replace_organization.return_value = replace_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["org", "replace", org_rid, new_name, "--confirm"]
+            )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.replace_organization.assert_called_once_with(
+            organization_rid=org_rid, name=new_name, description=None
+        )
+
+    def test_org_available_roles_command_success(self, runner, mock_service):
+        """Test successful organization available-roles command."""
+        # Setup
+        org_rid = "org123"
+        roles_result = {
+            "data": [
+                {"id": "role1", "name": "Admin"},
+                {"id": "role2", "name": "Editor"},
+            ],
+            "nextPageToken": None,
+        }
+        mock_service.list_available_roles.return_value = roles_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["org", "available-roles", org_rid])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.list_available_roles.assert_called_once()
+
+    # New Role Commands Tests
+    def test_role_batch_get_command_success(self, runner, mock_service):
+        """Test successful role batch get command."""
+        # Setup
+        batch_result = {
+            "data": [
+                {"id": "role1", "name": "Admin"},
+                {"id": "role2", "name": "Editor"},
+            ]
+        }
+        mock_service.get_batch_roles.return_value = batch_result
+
+        with patch("pltr.commands.admin.AdminService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(app, ["role", "batch-get", "role1", "role2"])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.get_batch_roles.assert_called_once()


### PR DESCRIPTION
## Summary

Implements #65 - Adds missing Admin module SDK functionality to the CLI.

### New Commands Added (13 total)

**User Management:**
- `pltr admin user delete <user_id>` - Delete a user (with confirmation)
- `pltr admin user batch-get <user_ids...>` - Batch retrieve up to 500 users

**Group Management:**
- `pltr admin group batch-get <group_ids...>` - Batch retrieve up to 500 groups

**Marking Management (NEW module):**
- `pltr admin marking list` - List all markings with pagination
- `pltr admin marking get <marking_id>` - Get specific marking
- `pltr admin marking batch-get <marking_ids...>` - Batch retrieve up to 500 markings
- `pltr admin marking create <name>` - Create new marking
- `pltr admin marking replace <marking_id> <name>` - Update existing marking

**Organization Management:**
- `pltr admin org create <name> --enrollment-rid <rid>` - Create new organization
- `pltr admin org replace <org_rid> <name>` - Update existing organization
- `pltr admin org available-roles <org_rid>` - List available roles

**Role Management:**
- `pltr admin role batch-get <role_ids...>` - Batch retrieve up to 500 roles

### Features
- Confirmation prompts for destructive operations (delete, replace)
- Batch size validation (max 500 items)
- Preview mode for Marking APIs as required by SDK
- Full support for `--profile`, `--format`, `--output` options

### Skipped
- `profile_picture` command (per discussion, deemed not useful)

## Test plan
- [x] All 82 admin tests pass (42 service + 40 command tests)
- [x] Pre-commit hooks pass (ruff, mypy, bandit)
- [ ] Manual testing with actual Foundry API (requires access)

Closes #65