### PR TITLE
feat: Add AIP Agents module support (Issue #108)

### DIFF
--- a/src/pltr/cli.py
+++ b/src/pltr/cli.py
@@ -25,6 +25,7 @@ from pltr.commands import (
     mediasets,
     connectivity,
     third_party_applications,
+    aip_agents,
 )
 from pltr.commands.cp import cp_command
 
@@ -60,6 +61,11 @@ app.add_typer(
     third_party_applications.app,
     name="third-party-apps",
     help="Manage third-party applications",
+)
+app.add_typer(
+    aip_agents.app,
+    name="aip-agents",
+    help="Manage AIP Agents, sessions, and versions",
 )
 app.add_typer(
     admin.app,

--- a/src/pltr/commands/aip_agents.py
+++ b/src/pltr/commands/aip_agents.py
@@ -1,0 +1,333 @@
+"""
+AIP Agents management commands for Foundry.
+Provides commands for agent inspection, session management, and version control.
+"""
+
+import typer
+from typing import Optional
+from rich.console import Console
+
+from ..services.aip_agents import AipAgentsService
+from ..utils.formatting import OutputFormatter
+from ..utils.progress import SpinnerProgressTracker
+from ..utils.pagination import PaginationConfig
+from ..auth.base import ProfileNotFoundError, MissingCredentialsError
+from ..utils.completion import (
+    complete_rid,
+    complete_profile,
+    complete_output_format,
+    cache_rid,
+)
+
+# Create main app and sub-apps
+app = typer.Typer(help="Manage AIP Agents, sessions, and versions")
+sessions_app = typer.Typer(help="Manage agent conversation sessions")
+versions_app = typer.Typer(help="Manage agent versions")
+
+# Add sub-apps
+app.add_typer(sessions_app, name="sessions")
+app.add_typer(versions_app, name="versions")
+
+console = Console()
+formatter = OutputFormatter(console)
+
+
+@app.command("get")
+def get_agent(
+    agent_rid: str = typer.Argument(
+        ...,
+        help="Agent Resource Identifier (e.g., ri.foundry.main.agent.abc123)",
+        autocompletion=complete_rid,
+    ),
+    version: Optional[str] = typer.Option(
+        None,
+        "--version",
+        "-v",
+        help="Agent version to retrieve (e.g., '1.0'). Defaults to latest published.",
+    ),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        "-p",
+        help="Profile name",
+        autocompletion=complete_profile,
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format (table, json, csv)",
+        autocompletion=complete_output_format,
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+):
+    """
+    Get detailed information about an AIP Agent.
+
+    Retrieves agent configuration including name, description, parameters,
+    and version information.
+
+    Examples:
+
+        # Get latest published version of agent
+        pltr aip-agents get ri.foundry.main.agent.abc123
+
+        # Get specific version
+        pltr aip-agents get ri.foundry.main.agent.abc123 --version 1.5
+
+        # Output as JSON
+        pltr aip-agents get ri.foundry.main.agent.abc123 --format json
+    """
+    try:
+        cache_rid(agent_rid)
+
+        service = AipAgentsService(profile=profile)
+
+        with SpinnerProgressTracker().track_spinner(f"Fetching agent {agent_rid}..."):
+            agent = service.get_agent(agent_rid, version=version)
+
+        if output:
+            formatter.save_to_file(agent, output, format)
+            formatter.print_success(f"Agent information saved to {output}")
+        else:
+            formatter.display(agent, format)
+
+    except (ProfileNotFoundError, MissingCredentialsError) as e:
+        formatter.print_error(f"Authentication error: {e}")
+        raise typer.Exit(1)
+    except ValueError as e:
+        formatter.print_error(f"Invalid request: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        formatter.print_error(f"Failed to get agent: {e}")
+        raise typer.Exit(1)
+
+
+@sessions_app.command("list")
+def list_sessions(
+    agent_rid: str = typer.Argument(
+        ...,
+        help="Agent Resource Identifier",
+        autocompletion=complete_rid,
+    ),
+    profile: Optional[str] = typer.Option(
+        None, "--profile", "-p", help="Profile name", autocompletion=complete_profile
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format (table, json, csv)",
+        autocompletion=complete_output_format,
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+    page_size: Optional[int] = typer.Option(
+        None, "--page-size", help="Number of sessions per page"
+    ),
+    max_pages: Optional[int] = typer.Option(
+        1, "--max-pages", help="Maximum number of pages to fetch (default: 1)"
+    ),
+    all: bool = typer.Option(
+        False, "--all", help="Fetch all available sessions (overrides --max-pages)"
+    ),
+):
+    """
+    List conversation sessions for an agent.
+
+    Only lists sessions created by this client (API). Sessions created
+    in AIP Agent Studio will not appear.
+
+    Examples:
+
+        # List first page of sessions
+        pltr aip-agents sessions list ri.foundry.main.agent.abc123
+
+        # List all sessions
+        pltr aip-agents sessions list ri.foundry.main.agent.abc123 --all
+
+        # List first 3 pages with 50 sessions each
+        pltr aip-agents sessions list ri.foundry.main.agent.abc123 \\
+            --page-size 50 --max-pages 3
+    """
+    try:
+        cache_rid(agent_rid)
+
+        service = AipAgentsService(profile=profile)
+        config = PaginationConfig(
+            page_size=page_size,
+            max_pages=max_pages,
+            fetch_all=all,
+        )
+
+        with SpinnerProgressTracker().track_spinner(
+            f"Fetching sessions for agent {agent_rid}..."
+        ):
+            result = service.list_sessions(agent_rid, config)
+
+        if not result.data:
+            console.print("[yellow]No sessions found for this agent[/yellow]")
+            return
+
+        if output:
+            formatter.format_paginated_output(result, format, output)
+            console.print(f"[green]Results saved to {output}[/green]")
+        else:
+            formatter.format_paginated_output(result, format)
+
+    except (ProfileNotFoundError, MissingCredentialsError) as e:
+        formatter.print_error(f"Authentication error: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        formatter.print_error(f"Failed to list sessions: {e}")
+        raise typer.Exit(1)
+
+
+@sessions_app.command("get")
+def get_session(
+    agent_rid: str = typer.Argument(
+        ...,
+        help="Agent Resource Identifier",
+        autocompletion=complete_rid,
+    ),
+    session_rid: str = typer.Argument(
+        ...,
+        help="Session Resource Identifier",
+        autocompletion=complete_rid,
+    ),
+    profile: Optional[str] = typer.Option(
+        None, "--profile", "-p", help="Profile name", autocompletion=complete_profile
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format (table, json, csv)",
+        autocompletion=complete_output_format,
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+):
+    """
+    Get detailed information about a conversation session.
+
+    Examples:
+
+        # Get session details
+        pltr aip-agents sessions get \\
+            ri.foundry.main.agent.abc123 \\
+            ri.foundry.main.session.xyz789
+
+        # Export session details to JSON
+        pltr aip-agents sessions get \\
+            ri.foundry.main.agent.abc123 \\
+            ri.foundry.main.session.xyz789 \\
+            --format json --output session.json
+    """
+    try:
+        cache_rid(agent_rid)
+        cache_rid(session_rid)
+
+        service = AipAgentsService(profile=profile)
+
+        with SpinnerProgressTracker().track_spinner(
+            f"Fetching session {session_rid}..."
+        ):
+            session = service.get_session(agent_rid, session_rid)
+
+        if output:
+            formatter.save_to_file(session, output, format)
+            formatter.print_success(f"Session information saved to {output}")
+        else:
+            formatter.display(session, format)
+
+    except (ProfileNotFoundError, MissingCredentialsError) as e:
+        formatter.print_error(f"Authentication error: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        formatter.print_error(f"Failed to get session: {e}")
+        raise typer.Exit(1)
+
+
+@versions_app.command("list")
+def list_versions(
+    agent_rid: str = typer.Argument(
+        ...,
+        help="Agent Resource Identifier",
+        autocompletion=complete_rid,
+    ),
+    profile: Optional[str] = typer.Option(
+        None, "--profile", "-p", help="Profile name", autocompletion=complete_profile
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format (table, json, csv)",
+        autocompletion=complete_output_format,
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+    page_size: Optional[int] = typer.Option(
+        None, "--page-size", help="Number of versions per page"
+    ),
+    max_pages: Optional[int] = typer.Option(
+        1, "--max-pages", help="Maximum number of pages to fetch (default: 1)"
+    ),
+    all: bool = typer.Option(
+        False, "--all", help="Fetch all available versions (overrides --max-pages)"
+    ),
+):
+    """
+    List all versions for an AIP Agent.
+
+    Versions are returned in descending order (most recent first).
+
+    Examples:
+
+        # List first page of versions
+        pltr aip-agents versions list ri.foundry.main.agent.abc123
+
+        # List all versions
+        pltr aip-agents versions list ri.foundry.main.agent.abc123 --all
+
+        # Export all versions to CSV
+        pltr aip-agents versions list ri.foundry.main.agent.abc123 \\
+            --all --format csv --output versions.csv
+    """
+    try:
+        cache_rid(agent_rid)
+
+        service = AipAgentsService(profile=profile)
+        config = PaginationConfig(
+            page_size=page_size,
+            max_pages=max_pages,
+            fetch_all=all,
+        )
+
+        with SpinnerProgressTracker().track_spinner(
+            f"Fetching versions for agent {agent_rid}..."
+        ):
+            result = service.list_versions(agent_rid, config)
+
+        if not result.data:
+            console.print("[yellow]No versions found for this agent[/yellow]")
+            return
+
+        if output:
+            formatter.format_paginated_output(result, format, output)
+            console.print(f"[green]Results saved to {output}[/green]")
+        else:
+            formatter.format_paginated_output(result, format)
+
+    except (ProfileNotFoundError, MissingCredentialsError) as e:
+        formatter.print_error(f"Authentication error: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        formatter.print_error(f"Failed to list versions: {e}")
+        raise typer.Exit(1)

--- a/src/pltr/services/aip_agents.py
+++ b/src/pltr/services/aip_agents.py
@@ -1,0 +1,147 @@
+"""
+AIP Agents service wrapper for Foundry SDK.
+Provides access to AIP Agent operations including agent details, sessions, and versions.
+"""
+
+from typing import Any, Dict, Optional
+from .base import BaseService
+from ..utils.pagination import PaginationConfig, PaginationResult
+
+
+class AipAgentsService(BaseService):
+    """Service wrapper for Foundry AIP Agents operations."""
+
+    def _get_service(self) -> Any:
+        """Get the Foundry AIP agents service."""
+        return self.client.aip_agents
+
+    # ===== Agent Operations =====
+
+    def get_agent(
+        self, agent_rid: str, version: Optional[str] = None, preview: bool = True
+    ) -> Dict[str, Any]:
+        """
+        Get details for an AIP Agent.
+
+        Args:
+            agent_rid: Agent Resource Identifier
+                Format: ri.foundry.main.agent.<id>
+            version: Optional agent version string (e.g., "1.0")
+                If not specified, returns latest published version
+            preview: Enable preview mode (default: True)
+
+        Returns:
+            Agent information dictionary containing:
+            - rid: Agent resource identifier
+            - version: Agent version
+            - metadata: Agent metadata (displayName, description, etc.)
+            - parameters: Application variables/parameters
+
+        Raises:
+            RuntimeError: If the operation fails
+
+        Example:
+            >>> service = AipAgentsService()
+            >>> agent = service.get_agent("ri.foundry.main.agent.abc123")
+            >>> print(agent['metadata']['displayName'])
+        """
+        try:
+            agent = self.service.Agent.get(agent_rid, version=version, preview=preview)
+            return self._serialize_response(agent)
+        except Exception as e:
+            raise RuntimeError(f"Failed to get agent {agent_rid}: {e}")
+
+    # ===== Session Operations =====
+
+    def list_sessions(
+        self, agent_rid: str, config: PaginationConfig, preview: bool = True
+    ) -> PaginationResult:
+        """
+        List all conversation sessions for an agent created by the calling user.
+
+        Note: Only lists sessions created by this client, not sessions created
+        in AIP Agent Studio.
+
+        Args:
+            agent_rid: Agent Resource Identifier
+            config: Pagination configuration
+            preview: Enable preview mode (default: True)
+
+        Returns:
+            PaginationResult with sessions and metadata
+
+        Example:
+            >>> config = PaginationConfig(page_size=20, max_pages=2)
+            >>> result = service.list_sessions(agent_rid, config)
+            >>> print(f"Found {result.metadata.items_fetched} sessions")
+        """
+        try:
+            iterator = self.service.Agent.Session.list(
+                agent_rid, page_size=config.page_size, preview=preview
+            )
+            return self._paginate_iterator(iterator, config)
+        except Exception as e:
+            raise RuntimeError(f"Failed to list sessions for agent {agent_rid}: {e}")
+
+    def get_session(
+        self, agent_rid: str, session_rid: str, preview: bool = True
+    ) -> Dict[str, Any]:
+        """
+        Get details of a specific conversation session.
+
+        Args:
+            agent_rid: Agent Resource Identifier
+            session_rid: Session Resource Identifier
+            preview: Enable preview mode (default: True)
+
+        Returns:
+            Session information dictionary containing:
+            - rid: Session resource identifier
+            - agent_rid: Associated agent RID
+            - agent_version: Agent version used in session
+            - metadata: Session metadata (e.g., title)
+
+        Raises:
+            RuntimeError: If the operation fails
+        """
+        try:
+            session = self.service.Agent.Session.get(
+                agent_rid, session_rid, preview=preview
+            )
+            return self._serialize_response(session)
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to get session {session_rid} for agent {agent_rid}: {e}"
+            )
+
+    # ===== Version Operations =====
+
+    def list_versions(
+        self, agent_rid: str, config: PaginationConfig, preview: bool = True
+    ) -> PaginationResult:
+        """
+        List all versions for an AIP Agent.
+
+        Versions are returned in descending order (most recent first).
+
+        Args:
+            agent_rid: Agent Resource Identifier
+            config: Pagination configuration
+            preview: Enable preview mode (default: True)
+
+        Returns:
+            PaginationResult with agent versions and metadata
+
+        Example:
+            >>> config = PaginationConfig(page_size=10, fetch_all=True)
+            >>> result = service.list_versions(agent_rid, config)
+            >>> for version in result.data:
+            ...     print(f"Version {version['string']}")
+        """
+        try:
+            iterator = self.service.Agent.AgentVersion.list(
+                agent_rid, page_size=config.page_size, preview=preview
+            )
+            return self._paginate_iterator(iterator, config)
+        except Exception as e:
+            raise RuntimeError(f"Failed to list versions for agent {agent_rid}: {e}")

--- a/tests/test_commands/test_aip_agents.py
+++ b/tests/test_commands/test_aip_agents.py
@@ -1,0 +1,458 @@
+"""Tests for AIP Agents commands."""
+
+import pytest
+from unittest.mock import Mock, patch
+from typer.testing import CliRunner
+from pltr.cli import app
+from pltr.utils.pagination import PaginationResult, PaginationMetadata
+
+
+class TestAipAgentsCommands:
+    """Test AIP Agents CLI commands."""
+
+    @pytest.fixture
+    def runner(self):
+        """Create CLI test runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_service(self):
+        """Create mock AipAgentsService."""
+        with patch("pltr.commands.aip_agents.AipAgentsService") as MockService:
+            mock_svc = Mock()
+            MockService.return_value = mock_svc
+            yield mock_svc
+
+    def test_get_agent_success(self, runner, mock_service):
+        """Test successful get agent command."""
+        # Setup
+        agent_result = {
+            "rid": "ri.foundry.main.agent.abc123",
+            "version": "1.0",
+            "metadata": {
+                "displayName": "Test Agent",
+                "description": "A test agent",
+            },
+        }
+        mock_service.get_agent.return_value = agent_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "get",
+                "ri.foundry.main.agent.abc123",
+                "--format",
+                "json",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.get_agent.assert_called_once_with(
+            "ri.foundry.main.agent.abc123", version=None
+        )
+
+    def test_get_agent_with_version(self, runner, mock_service):
+        """Test get agent with specific version."""
+        # Setup
+        agent_result = {
+            "rid": "ri.foundry.main.agent.abc123",
+            "version": "1.5",
+        }
+        mock_service.get_agent.return_value = agent_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "get",
+                "ri.foundry.main.agent.abc123",
+                "--version",
+                "1.5",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.get_agent.assert_called_once_with(
+            "ri.foundry.main.agent.abc123", version="1.5"
+        )
+
+    def test_get_agent_with_profile(self, runner, mock_service):
+        """Test get agent with profile option."""
+        # Setup
+        agent_result = {
+            "rid": "ri.foundry.main.agent.abc123",
+            "version": "1.0",
+        }
+        mock_service.get_agent.return_value = agent_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "get",
+                "ri.foundry.main.agent.abc123",
+                "--profile",
+                "test-profile",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        # Verify service was initialized with profile
+        from pltr.commands.aip_agents import AipAgentsService
+
+        AipAgentsService.assert_called_with(profile="test-profile")
+
+    def test_get_agent_error(self, runner, mock_service):
+        """Test get agent command with service error."""
+        # Setup
+        mock_service.get_agent.side_effect = RuntimeError("Agent not found")
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "get",
+                "ri.foundry.main.agent.invalid",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 1
+        assert "Failed to get agent" in result.stdout
+
+    def test_list_sessions_success(self, runner, mock_service):
+        """Test successful list sessions command."""
+        # Setup
+        sessions_result = PaginationResult(
+            data=[
+                {
+                    "rid": "session1",
+                    "agent_rid": "ri.foundry.main.agent.abc123",
+                    "metadata": {"title": "Chat 1"},
+                },
+                {
+                    "rid": "session2",
+                    "agent_rid": "ri.foundry.main.agent.abc123",
+                    "metadata": {"title": "Chat 2"},
+                },
+            ],
+            metadata=PaginationMetadata(items_fetched=2, has_more=False),
+        )
+        mock_service.list_sessions.return_value = sessions_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "sessions",
+                "list",
+                "ri.foundry.main.agent.abc123",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.list_sessions.assert_called_once()
+
+    def test_list_sessions_with_pagination(self, runner, mock_service):
+        """Test list sessions with pagination options."""
+        # Setup
+        sessions_result = PaginationResult(
+            data=[],
+            metadata=PaginationMetadata(items_fetched=0, has_more=False),
+        )
+        mock_service.list_sessions.return_value = sessions_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "sessions",
+                "list",
+                "ri.foundry.main.agent.abc123",
+                "--page-size",
+                "50",
+                "--max-pages",
+                "3",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.list_sessions.assert_called_once()
+        # Verify PaginationConfig was created correctly
+        call_args = mock_service.list_sessions.call_args
+        config = call_args[0][1]  # Second positional argument
+        assert config.page_size == 50
+        assert config.max_pages == 3
+
+    def test_list_sessions_all(self, runner, mock_service):
+        """Test list sessions with --all flag."""
+        # Setup
+        sessions_result = PaginationResult(
+            data=[],
+            metadata=PaginationMetadata(items_fetched=0, has_more=False),
+        )
+        mock_service.list_sessions.return_value = sessions_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "sessions",
+                "list",
+                "ri.foundry.main.agent.abc123",
+                "--all",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        call_args = mock_service.list_sessions.call_args
+        config = call_args[0][1]
+        assert config.fetch_all is True
+
+    def test_list_sessions_empty(self, runner, mock_service):
+        """Test list sessions when no sessions found."""
+        # Setup
+        sessions_result = PaginationResult(
+            data=[],
+            metadata=PaginationMetadata(items_fetched=0, has_more=False),
+        )
+        mock_service.list_sessions.return_value = sessions_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "sessions",
+                "list",
+                "ri.foundry.main.agent.abc123",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        assert "No sessions found" in result.stdout
+
+    def test_list_sessions_error(self, runner, mock_service):
+        """Test list sessions command with error."""
+        # Setup
+        mock_service.list_sessions.side_effect = RuntimeError("Failed to list")
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "sessions",
+                "list",
+                "ri.foundry.main.agent.abc123",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 1
+        assert "Failed to list sessions" in result.stdout
+
+    def test_get_session_success(self, runner, mock_service):
+        """Test successful get session command."""
+        # Setup
+        session_result = {
+            "rid": "ri.foundry.main.session.xyz789",
+            "agent_rid": "ri.foundry.main.agent.abc123",
+            "agent_version": "1.0",
+            "metadata": {"title": "Test Session"},
+        }
+        mock_service.get_session.return_value = session_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "sessions",
+                "get",
+                "ri.foundry.main.agent.abc123",
+                "ri.foundry.main.session.xyz789",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.get_session.assert_called_once_with(
+            "ri.foundry.main.agent.abc123",
+            "ri.foundry.main.session.xyz789",
+        )
+
+    def test_get_session_error(self, runner, mock_service):
+        """Test get session command with error."""
+        # Setup
+        mock_service.get_session.side_effect = RuntimeError("Session not found")
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "sessions",
+                "get",
+                "ri.foundry.main.agent.abc123",
+                "ri.foundry.main.session.xyz789",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 1
+        assert "Failed to get session" in result.stdout
+
+    def test_list_versions_success(self, runner, mock_service):
+        """Test successful list versions command."""
+        # Setup
+        versions_result = PaginationResult(
+            data=[
+                {"string": "1.2", "published": True},
+                {"string": "1.1", "published": True},
+            ],
+            metadata=PaginationMetadata(items_fetched=2, has_more=False),
+        )
+        mock_service.list_versions.return_value = versions_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "versions",
+                "list",
+                "ri.foundry.main.agent.abc123",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        mock_service.list_versions.assert_called_once()
+
+    def test_list_versions_all(self, runner, mock_service):
+        """Test list versions with --all flag."""
+        # Setup
+        versions_result = PaginationResult(
+            data=[],
+            metadata=PaginationMetadata(items_fetched=0, has_more=False),
+        )
+        mock_service.list_versions.return_value = versions_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "versions",
+                "list",
+                "ri.foundry.main.agent.abc123",
+                "--all",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        call_args = mock_service.list_versions.call_args
+        config = call_args[0][1]
+        assert config.fetch_all is True
+
+    def test_list_versions_empty(self, runner, mock_service):
+        """Test list versions when no versions found."""
+        # Setup
+        versions_result = PaginationResult(
+            data=[],
+            metadata=PaginationMetadata(items_fetched=0, has_more=False),
+        )
+        mock_service.list_versions.return_value = versions_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "versions",
+                "list",
+                "ri.foundry.main.agent.abc123",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        assert "No versions found" in result.stdout
+
+    def test_list_versions_error(self, runner, mock_service):
+        """Test list versions command with error."""
+        # Setup
+        mock_service.list_versions.side_effect = RuntimeError("Failed to list")
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "versions",
+                "list",
+                "ri.foundry.main.agent.abc123",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 1
+        assert "Failed to list versions" in result.stdout
+
+    def test_help_commands(self, runner):
+        """Test help output for commands."""
+        # Test main help
+        result = runner.invoke(app, ["aip-agents", "--help"])
+        assert result.exit_code == 0
+        assert "AIP Agents" in result.stdout
+
+        # Test sessions help
+        result = runner.invoke(app, ["aip-agents", "sessions", "--help"])
+        assert result.exit_code == 0
+        assert "conversation sessions" in result.stdout.lower()
+
+        # Test versions help
+        result = runner.invoke(app, ["aip-agents", "versions", "--help"])
+        assert result.exit_code == 0
+        assert "versions" in result.stdout.lower()
+
+    def test_get_agent_json_format(self, runner, mock_service):
+        """Test get agent with JSON output format."""
+        # Setup
+        agent_result = {
+            "rid": "ri.foundry.main.agent.abc123",
+            "version": "1.0",
+        }
+        mock_service.get_agent.return_value = agent_result
+
+        # Execute
+        result = runner.invoke(
+            app,
+            [
+                "aip-agents",
+                "get",
+                "ri.foundry.main.agent.abc123",
+                "--format",
+                "json",
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0

--- a/tests/test_services/test_aip_agents.py
+++ b/tests/test_services/test_aip_agents.py
@@ -1,0 +1,204 @@
+"""Tests for AIP Agents service."""
+
+import pytest
+from unittest.mock import Mock, patch
+from pltr.services.aip_agents import AipAgentsService
+from pltr.utils.pagination import PaginationConfig
+
+
+class TestAipAgentsService:
+    """Test AIP Agents service functionality."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock Foundry client."""
+        client = Mock()
+        client.aip_agents = Mock()
+        client.aip_agents.Agent = Mock()
+        client.aip_agents.Agent.Session = Mock()
+        client.aip_agents.Agent.AgentVersion = Mock()
+        return client
+
+    @pytest.fixture
+    def service(self, mock_client):
+        """Create AipAgentsService with mocked client."""
+        with patch("pltr.services.base.AuthManager") as mock_auth:
+            mock_auth.return_value.get_client.return_value = mock_client
+            service = AipAgentsService()
+            return service
+
+    def test_get_agent(self, service, mock_client):
+        """Test getting an agent."""
+        # Setup
+        agent_rid = "ri.foundry.main.agent.abc123"
+        mock_response = Mock()
+        mock_response.dict.return_value = {
+            "rid": agent_rid,
+            "version": "1.0",
+            "metadata": {
+                "displayName": "Test Agent",
+                "description": "A test agent",
+            },
+        }
+        mock_client.aip_agents.Agent.get.return_value = mock_response
+
+        # Execute
+        result = service.get_agent(agent_rid)
+
+        # Assert
+        mock_client.aip_agents.Agent.get.assert_called_once_with(
+            agent_rid, version=None, preview=True
+        )
+        assert result["rid"] == agent_rid
+        assert result["metadata"]["displayName"] == "Test Agent"
+
+    def test_get_agent_with_version(self, service, mock_client):
+        """Test getting a specific agent version."""
+        # Setup
+        agent_rid = "ri.foundry.main.agent.abc123"
+        version = "1.5"
+        mock_response = Mock()
+        mock_response.dict.return_value = {
+            "rid": agent_rid,
+            "version": version,
+        }
+        mock_client.aip_agents.Agent.get.return_value = mock_response
+
+        # Execute
+        result = service.get_agent(agent_rid, version=version)
+
+        # Assert
+        mock_client.aip_agents.Agent.get.assert_called_once_with(
+            agent_rid, version=version, preview=True
+        )
+        assert result["version"] == version
+
+    def test_get_agent_error(self, service, mock_client):
+        """Test error handling in get_agent."""
+        # Setup
+        agent_rid = "ri.foundry.main.agent.invalid"
+        mock_client.aip_agents.Agent.get.side_effect = Exception("Agent not found")
+
+        # Execute & Assert
+        with pytest.raises(RuntimeError, match="Failed to get agent"):
+            service.get_agent(agent_rid)
+
+    def test_list_sessions(self, service, mock_client):
+        """Test listing sessions for an agent."""
+        # Setup
+        agent_rid = "ri.foundry.main.agent.abc123"
+        config = PaginationConfig(page_size=10, max_pages=1)
+
+        # Create a mock that returns a single session to avoid empty iterator issue
+        mock_session = Mock()
+        mock_session.dict.return_value = {
+            "rid": "session1",
+            "agent_rid": agent_rid,
+        }
+
+        # Create a mock iterator
+        mock_iterator = Mock()
+        mock_iterator.__iter__ = Mock(return_value=iter([mock_session]))
+        mock_iterator.next_page_token = None
+        mock_client.aip_agents.Agent.Session.list.return_value = mock_iterator
+
+        # Execute
+        result = service.list_sessions(agent_rid, config)
+
+        # Assert - Just verify the SDK method was called correctly
+        mock_client.aip_agents.Agent.Session.list.assert_called_once_with(
+            agent_rid, page_size=10, preview=True
+        )
+        # Verify result was returned
+        assert result is not None
+        assert hasattr(result, "data")
+
+    def test_list_sessions_error(self, service, mock_client):
+        """Test error handling in list_sessions."""
+        # Setup
+        agent_rid = "ri.foundry.main.agent.abc123"
+        mock_client.aip_agents.Agent.Session.list.side_effect = Exception(
+            "Failed to list"
+        )
+        config = PaginationConfig(page_size=10, max_pages=1)
+
+        # Execute & Assert
+        with pytest.raises(RuntimeError, match="Failed to list sessions"):
+            service.list_sessions(agent_rid, config)
+
+    def test_get_session(self, service, mock_client):
+        """Test getting a specific session."""
+        # Setup
+        agent_rid = "ri.foundry.main.agent.abc123"
+        session_rid = "ri.foundry.main.session.xyz789"
+        mock_response = Mock()
+        mock_response.dict.return_value = {
+            "rid": session_rid,
+            "agent_rid": agent_rid,
+            "agent_version": "1.0",
+            "metadata": {"title": "Test Session"},
+        }
+        mock_client.aip_agents.Agent.Session.get.return_value = mock_response
+
+        # Execute
+        result = service.get_session(agent_rid, session_rid)
+
+        # Assert
+        mock_client.aip_agents.Agent.Session.get.assert_called_once_with(
+            agent_rid, session_rid, preview=True
+        )
+        assert result["rid"] == session_rid
+        assert result["agent_rid"] == agent_rid
+
+    def test_get_session_error(self, service, mock_client):
+        """Test error handling in get_session."""
+        # Setup
+        agent_rid = "ri.foundry.main.agent.abc123"
+        session_rid = "ri.foundry.main.session.xyz789"
+        mock_client.aip_agents.Agent.Session.get.side_effect = Exception(
+            "Session not found"
+        )
+
+        # Execute & Assert
+        with pytest.raises(RuntimeError, match="Failed to get session"):
+            service.get_session(agent_rid, session_rid)
+
+    def test_list_versions(self, service, mock_client):
+        """Test listing agent versions."""
+        # Setup
+        agent_rid = "ri.foundry.main.agent.abc123"
+        config = PaginationConfig(page_size=10, fetch_all=True)
+
+        # Create a mock that returns a single version to avoid empty iterator issue
+        mock_version = Mock()
+        mock_version.dict.return_value = {"string": "1.0", "published": True}
+
+        # Create a mock iterator
+        mock_iterator = Mock()
+        mock_iterator.__iter__ = Mock(return_value=iter([mock_version]))
+        mock_iterator.next_page_token = None
+        mock_client.aip_agents.Agent.AgentVersion.list.return_value = mock_iterator
+
+        # Execute
+        result = service.list_versions(agent_rid, config)
+
+        # Assert - Just verify the SDK method was called correctly
+        mock_client.aip_agents.Agent.AgentVersion.list.assert_called_once_with(
+            agent_rid, page_size=10, preview=True
+        )
+        # Verify result was returned
+        assert result is not None
+        assert hasattr(result, "data")
+
+    def test_list_versions_error(self, service, mock_client):
+        """Test error handling in list_versions."""
+        # Setup
+        agent_rid = "ri.foundry.main.agent.abc123"
+        mock_client.aip_agents.Agent.AgentVersion.list.side_effect = Exception(
+            "Failed to list versions"
+        )
+        config = PaginationConfig(page_size=10, max_pages=1)
+
+        # Execute & Assert
+        with pytest.raises(RuntimeError, match="Failed to list versions"):
+            service.list_versions(agent_rid, config)


### PR DESCRIPTION
## Overview
This PR adds support for the AIP Agents module from the Foundry Platform SDK, enabling AI/ML agent interactions through the CLI.

Closes #108

## Implementation

### MVP Scope
Implements 4 core read-only commands:
- `pltr aip-agents get <agent-rid>` - Get agent details
- `pltr aip-agents sessions list <agent-rid>` - List sessions for an agent
- `pltr aip-agents sessions get <agent-rid> <session-rid>` - Get session details
- `pltr aip-agents versions list <agent-rid>` - List agent versions

### Changes

#### Service Layer (`src/pltr/services/aip_agents.py`)
- New `AipAgentsService` class inheriting from `BaseService`
- Implements 4 methods: `get_agent`, `list_sessions`, `get_session`, `list_versions`
- Uses `_paginate_iterator` for list operations (SDK returns ResourceIterator)
- All operations default to `preview=True` for SDK compatibility
- Proper error handling with contextual RuntimeError messages

#### Command Layer (`src/pltr/commands/aip_agents.py`)
- Main `aip-agents` command group with sub-apps for `sessions` and `versions`
- Full pagination support: `--page-size`, `--max-pages`, `--all` options
- Output formatting: table, json, csv with optional file output (`--output`)
- RID caching for autocompletion
- Rich help text with usage examples

#### CLI Integration (`src/pltr/cli.py`)
- Registered `aip-agents` command group in main CLI

#### Tests
- **Service tests** (`tests/test_services/test_aip_agents.py`): 9 tests
  - Success paths for all 4 operations
  - Error handling for all operations
  - Pagination configuration verification
- **Command tests** (`tests/test_commands/test_aip_agents.py`): 17 tests
  - CLI invocation with various options
  - Pagination options (page-size, max-pages, all)
  - Profile selection
  - Output formats
  - Error handling
  - Help text verification

All 26 tests passing ✅

## Technical Details

### SDK Integration
- SDK uses nested structure: `client.aip_agents.Agent.Session.list()`
- Service method `_get_service()` returns `self.client.aip_agents`
- Calls are made via `self.service.Agent.get()`, `self.service.Agent.Session.list()`, etc.

### RID Formats
- Agent RID: `ri.foundry.main.agent.<id>`
- Session RID: `ri.foundry.main.session.<id>`
- Both cached for autocompletion

### Preview Mode
- All AIP agent operations require `preview=True`
- Defaulted in service methods, not exposed to CLI users

### Pagination
- Uses `_paginate_iterator()` from BaseService
- SDK ResourceIterator handles page tokens internally
- Sessions and versions returned most recent first

## Future Enhancements (Not in MVP)
Deferred for future PRs based on user feedback:
- Session creation and management
- Interactive conversation features (blocking/streaming continue)
- Session content retrieval
- RAG context operations
- Session trace operations

## Testing
```bash
# Run AIP agents tests
uv run pytest tests/test_services/test_aip_agents.py tests/test_commands/test_aip_agents.py -v

# All 26 tests pass
```

## Examples

```bash
# Get agent details
pltr aip-agents get ri.foundry.main.agent.abc123

# Get specific version
pltr aip-agents get ri.foundry.main.agent.abc123 --version 1.5

# List all sessions
pltr aip-agents sessions list ri.foundry.main.agent.abc123 --all

# Get session details
pltr aip-agents sessions get ri.foundry.main.agent.abc123 ri.foundry.main.session.xyz789

# List versions with pagination
pltr aip-agents versions list ri.foundry.main.agent.abc123 --page-size 10 --max-pages 3

# Export to JSON
pltr aip-agents get ri.foundry.main.agent.abc123 --format json --output agent.json
```

## Checklist
- [x] Service layer implements 4 methods following BaseService patterns
- [x] Command layer implements 4 commands with sub-apps structure
- [x] All service tests pass (9 tests)
- [x] All command tests pass (17 tests)
- [x] Help text includes examples and RID format documentation
- [x] Error messages are user-friendly with context
- [x] Code follows existing patterns (connectivity, admin modules)
- [x] CLI registration complete
- [x] Pre-commit hooks pass (ruff, mypy, bandit)