### PR TITLE
Handle pginated results in user and group list

### DIFF
--- a/src/pltr/commands/admin.py
+++ b/src/pltr/commands/admin.py
@@ -394,12 +394,22 @@ def list_groups(
         with SpinnerProgressTracker().track_spinner("Fetching groups..."):
             result = service.list_groups(page_size=page_size, page_token=page_token)
 
+        # Extract data from result (service returns {data: [...], next_page_token: ...})
+        groups = result.get("data", [])
+        next_token = result.get("next_page_token")
+
         # Format and display results
         if output_file:
-            formatter.save_to_file(result, output_file, output_format)
+            formatter.save_to_file(groups, output_file, output_format)
             console.print(f"Results saved to {output_file}")
         else:
-            formatter.display(result, output_format)
+            formatter.display(groups, output_format)
+
+        # Show pagination info
+        if next_token:
+            console.print(
+                f"\n[dim]More results available. Use --page-token {next_token} to continue[/dim]"
+            )
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/tests/test_services/test_admin.py
+++ b/tests/test_services/test_admin.py
@@ -167,20 +167,23 @@ class TestAdminService:
     # Group Management Tests
     def test_list_groups(self, service, mock_client):
         """Test listing all groups."""
-        # Setup
-        mock_response = Mock()
-        mock_response.dict.return_value = {
-            "groups": [
-                {
-                    "id": "group1",
-                    "name": "Engineering",
-                    "description": "Engineering team",
-                },
-                {"id": "group2", "name": "Product", "description": "Product team"},
-            ],
-            "nextPageToken": None,
+        # Setup - mock ResourceIterator with .data and .next_page_token
+        mock_group1 = Mock()
+        mock_group1.dict.return_value = {
+            "id": "group1",
+            "name": "Engineering",
+            "description": "Engineering team",
         }
-        mock_client.admin.Group.list.return_value = mock_response
+        mock_group2 = Mock()
+        mock_group2.dict.return_value = {
+            "id": "group2",
+            "name": "Product",
+            "description": "Product team",
+        }
+        mock_iterator = Mock()
+        mock_iterator.data = [mock_group1, mock_group2]
+        mock_iterator.next_page_token = None
+        mock_client.admin.Group.list.return_value = mock_iterator
 
         # Execute
         result = service.list_groups()
@@ -189,8 +192,10 @@ class TestAdminService:
         mock_client.admin.Group.list.assert_called_once_with(
             page_size=None, page_token=None
         )
-        assert "groups" in result
-        assert len(result["groups"]) == 2
+        assert "data" in result
+        assert len(result["data"]) == 2
+        assert result["data"][0]["id"] == "group1"
+        assert result["data"][1]["id"] == "group2"
 
     def test_get_group(self, service, mock_client):
         """Test getting a specific group."""


### PR DESCRIPTION
## Description

### Problem
The `pltr admin user list` and `pltr admin group list` commands return 0 results even when the user has proper permissions and the API is working correctly.

```bash
$ pltr admin user list
No data to display
ℹ️  Fetched 0 items (page 1)
No more pages available
```

Meanwhile, pltr admin user current works fine, confirming authentication is valid.

### Root Cause

The Foundry SDK's User.list() and Group.list() methods return a ResourceIterator object (with .data and .next_page_token attributes), not a serializable response object.

The service layer was calling _serialize_response() directly on the iterator. Since ResourceIterator's internal attributes are prefixed with _, the serialization method filtered them all out and returned an empty dictionary {}. The pagination handler then extracted response.get("data", []) and got an empty list.

### Affected Commands

  - `pltr admin user list`
  - `pltr admin group list`

### Fix

Updated the service methods to properly extract data from the ResourceIterator:

**Before (broken)**

```
response = self.service.User.list(page_size=page_size, page_token=page_token)
return self._serialize_response(response)  # Returns {}
```

**After (fixed)**
```
iterator = self.service.User.list(page_size=page_size, page_token=page_token)
return {
    "data": [self._serialize_response(user) for user in iterator.data],
    "next_page_token": iterator.next_page_token,
}
```

### Files Changed

  - `src/pltr/services/admin.py` - Fixed list_users_paginated() and list_groups()
  - `src/pltr/commands/admin.py` - Updated list_groups command to handle new response structure
  - `tests/test_services/test_admin.py` - Updated test mocks for ResourceIterator pattern