### PR TITLE
docs: Address PR #117 review feedback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "click-repl>=0.3.0",
-    "foundry-platform-sdk>=1.69.0",
+    "foundry-platform-sdk>=1.69.0,<2.0.0",
     "keyring>=25.6.0",
     "pandas>=2.0.0",
     "python-dotenv>=1.1.1",

--- a/src/pltr/services/dataset.py
+++ b/src/pltr/services/dataset.py
@@ -18,8 +18,6 @@ class DatasetService(BaseService):
         """Get the Foundry datasets service."""
         return self.client.datasets
 
-    # list_datasets method removed - not supported by foundry-platform-sdk v1.27.0
-
     def get_dataset(self, dataset_rid: str) -> Dict[str, Any]:
         """
         Get information about a specific dataset.
@@ -254,6 +252,7 @@ class DatasetService(BaseService):
             # Clean column name (remove special characters for field name)
             clean_name = col.strip().replace(" ", "_").replace("-", "_")
 
+            # SDK 1.69.0 expects FieldType enum but accepts strings at runtime
             fields.append(
                 DatasetFieldSchema(name=clean_name, type=field_type, nullable=nullable)  # type: ignore[arg-type]
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click-repl", specifier = ">=0.3.0" },
-    { name = "foundry-platform-sdk", specifier = ">=1.69.0" },
+    { name = "foundry-platform-sdk", specifier = ">=1.69.0,<2.0.0" },
     { name = "keyring", specifier = ">=25.6.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },


### PR DESCRIPTION
## Summary
Address minor suggestions from PR #117 review to improve code documentation and dependency management.

## Changes
- **Documentation**: Added explanatory comment for type ignore in dataset.py:257 to clarify why SDK 1.69.0 accepts strings at runtime despite expecting FieldType enum
- **Cleanup**: Removed outdated SDK version comment referencing v1.27.0 at dataset.py:21
- **Dependency management**: Added upper bound `<2.0.0` to foundry-platform-sdk dependency to prevent automatic installation of potentially breaking major version updates

## Testing
- ✅ All 892 tests pass
- ✅ All pre-commit hooks pass (ruff, mypy, bandit)
- ✅ Lockfile updated successfully

## Related
- Follow-up to #117