### PR TITLE
docs: Update Claude skill with 5 new modules

### DIFF
--- a/claude_skill/SKILL.md
+++ b/claude_skill/SKILL.md
@@ -9,14 +9,14 @@ This skill helps you use the pltr-cli to interact with Palantir Foundry effectiv
 
 ## Compatibility
 
-- **Skill version**: 1.0.0
-- **pltr-cli version**: 0.11.0+
+- **Skill version**: 1.1.0
+- **pltr-cli version**: 0.12.0+
 - **Python**: 3.9, 3.10, 3.11, 3.12
-- **Dependencies**: foundry-platform-sdk >= 1.27.0
+- **Dependencies**: foundry-platform-sdk >= 1.69.0
 
 ## Overview
 
-pltr-cli is a comprehensive CLI with 80+ commands for:
+pltr-cli is a comprehensive CLI with 100+ commands for:
 - **Dataset operations**: Get info, list files, download files, manage branches and transactions
 - **SQL queries**: Execute queries, export results, manage async queries
 - **Ontology**: List ontologies, object types, objects, execute actions and queries
@@ -25,6 +25,11 @@ pltr-cli is a comprehensive CLI with 80+ commands for:
 - **Admin**: User, group, role management
 - **Connectivity**: External connections and data imports
 - **MediaSets**: Media file management
+- **Language Models**: Interact with Anthropic Claude models and OpenAI embeddings
+- **Streams**: Create and manage streaming datasets, publish real-time data
+- **Functions**: Execute queries and inspect value types
+- **AIP Agents**: Manage AI agents, sessions, and versions
+- **Models**: ML model registry for model and version management
 
 ## Critical Concepts
 
@@ -83,6 +88,11 @@ Load these files based on the user's task:
 | Folders, spaces, projects, resources, permissions | `reference/filesystem-commands.md` |
 | Connections, imports | `reference/connectivity-commands.md` |
 | Media sets, media items | `reference/mediasets-commands.md` |
+| Anthropic Claude models, OpenAI embeddings | `reference/language-models-commands.md` |
+| Streaming datasets, real-time data publishing | `reference/streams-commands.md` |
+| Functions queries, value types | `reference/functions-commands.md` |
+| AIP Agents, sessions, versions | `reference/aip-agents-commands.md` |
+| ML model registry, model versions | `reference/models-commands.md` |
 
 ## Workflow Files
 
@@ -126,6 +136,39 @@ pltr orchestration builds search
 
 # Interactive shell mode
 pltr shell
+
+# Send message to Claude model
+pltr language-models anthropic messages ri.language-models.main.model.xxx \
+    --message "Explain this concept"
+
+# Generate embeddings
+pltr language-models openai embeddings ri.language-models.main.model.xxx \
+    --input "Sample text"
+
+# Create streaming dataset
+pltr streams dataset create my-stream \
+    --folder ri.compass.main.folder.xxx \
+    --schema '{"fieldSchemaList": [{"name": "value", "type": "STRING"}]}'
+
+# Publish record to stream
+pltr streams stream publish ri.foundry.main.dataset.xxx \
+    --branch master \
+    --record '{"value": "hello"}'
+
+# Execute a function query
+pltr functions query execute myQuery --parameters '{"limit": 10}'
+
+# Get AIP Agent info
+pltr aip-agents get ri.foundry.main.agent.abc123
+
+# List agent sessions
+pltr aip-agents sessions list ri.foundry.main.agent.abc123
+
+# Get ML model info
+pltr models model get ri.foundry.main.model.abc123
+
+# List model versions
+pltr models version list ri.foundry.main.model.abc123
 ```
 
 ## Best Practices

--- a/claude_skill/reference/aip-agents-commands.md
+++ b/claude_skill/reference/aip-agents-commands.md
@@ -1,0 +1,209 @@
+# AIP Agents Commands
+
+Commands for managing AIP Agents, their conversation sessions, and version history in Foundry.
+
+## RID Formats
+- **Agent**: `ri.foundry.main.agent.{uuid}`
+- **Session**: `ri.foundry.main.session.{uuid}`
+
+## Agent Commands
+
+### Get Agent
+
+Get detailed information about an AIP Agent.
+
+```bash
+pltr aip-agents get AGENT_RID [OPTIONS]
+
+# Options:
+#   --version, -v TEXT      Agent version (e.g., '1.0') [default: latest published]
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Get latest published version of agent
+pltr aip-agents get ri.foundry.main.agent.abc123
+
+# Get specific version
+pltr aip-agents get ri.foundry.main.agent.abc123 --version 1.5
+
+# Output as JSON
+pltr aip-agents get ri.foundry.main.agent.abc123 --format json
+
+# Save to file
+pltr aip-agents get ri.foundry.main.agent.abc123 \
+    --format json \
+    --output agent-info.json
+```
+
+## Session Commands
+
+### List Sessions
+
+List conversation sessions for an agent.
+
+**Important:** This only lists sessions created via the API. Sessions created in AIP Agent Studio will not appear.
+
+```bash
+pltr aip-agents sessions list AGENT_RID [OPTIONS]
+
+# Options:
+#   --page-size INTEGER     Number of sessions per page
+#   --max-pages INTEGER     Maximum pages to fetch [default: 1]
+#   --all                   Fetch all available sessions (overrides --max-pages)
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# List first page of sessions
+pltr aip-agents sessions list ri.foundry.main.agent.abc123
+
+# List all sessions
+pltr aip-agents sessions list ri.foundry.main.agent.abc123 --all
+
+# List first 3 pages with 50 sessions each
+pltr aip-agents sessions list ri.foundry.main.agent.abc123 \
+    --page-size 50 --max-pages 3
+
+# Export to CSV
+pltr aip-agents sessions list ri.foundry.main.agent.abc123 \
+    --all --format csv --output sessions.csv
+```
+
+### Get Session
+
+Get detailed information about a specific conversation session.
+
+```bash
+pltr aip-agents sessions get AGENT_RID SESSION_RID [OPTIONS]
+
+# Options:
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Get session details
+pltr aip-agents sessions get \
+    ri.foundry.main.agent.abc123 \
+    ri.foundry.main.session.xyz789
+
+# Export session details to JSON
+pltr aip-agents sessions get \
+    ri.foundry.main.agent.abc123 \
+    ri.foundry.main.session.xyz789 \
+    --format json --output session.json
+```
+
+## Version Commands
+
+### List Versions
+
+List all versions for an AIP Agent. Versions are returned in descending order (most recent first).
+
+```bash
+pltr aip-agents versions list AGENT_RID [OPTIONS]
+
+# Options:
+#   --page-size INTEGER     Number of versions per page
+#   --max-pages INTEGER     Maximum pages to fetch [default: 1]
+#   --all                   Fetch all available versions (overrides --max-pages)
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# List first page of versions
+pltr aip-agents versions list ri.foundry.main.agent.abc123
+
+# List all versions
+pltr aip-agents versions list ri.foundry.main.agent.abc123 --all
+
+# Export all versions to CSV
+pltr aip-agents versions list ri.foundry.main.agent.abc123 \
+    --all --format csv --output versions.csv
+```
+
+## Session Visibility Note
+
+**API Sessions Only:** The `sessions list` command only shows sessions created through the API. Sessions created interactively in AIP Agent Studio are not visible through this endpoint.
+
+To work with all sessions including those from AIP Agent Studio, use the Foundry web interface.
+
+## Pagination
+
+Both `sessions list` and `versions list` support pagination:
+
+| Option | Description |
+|--------|-------------|
+| `--page-size N` | Number of items per page |
+| `--max-pages N` | Maximum pages to fetch (default: 1) |
+| `--all` | Fetch all available items |
+
+```bash
+# Fetch first 100 sessions across 2 pages of 50 each
+pltr aip-agents sessions list ri.foundry.main.agent.abc123 \
+    --page-size 50 --max-pages 2
+
+# Fetch everything
+pltr aip-agents sessions list ri.foundry.main.agent.abc123 --all
+```
+
+## Common Patterns
+
+### Inspect Agent Before Using
+
+```bash
+# Get agent details to understand its capabilities
+pltr aip-agents get ri.foundry.main.agent.abc123 --format json
+
+# Check available versions
+pltr aip-agents versions list ri.foundry.main.agent.abc123
+```
+
+### Export Session History
+
+```bash
+# List all sessions and export
+pltr aip-agents sessions list ri.foundry.main.agent.abc123 \
+    --all \
+    --format json \
+    --output all-sessions.json
+
+# Get details for specific session
+pltr aip-agents sessions get \
+    ri.foundry.main.agent.abc123 \
+    ri.foundry.main.session.xyz789 \
+    --format json \
+    --output session-details.json
+```
+
+### Track Agent Version History
+
+```bash
+# Export complete version history
+pltr aip-agents versions list ri.foundry.main.agent.abc123 \
+    --all \
+    --format csv \
+    --output agent-versions.csv
+```
+
+### Compare Agent Versions
+
+```bash
+# Get specific version details
+pltr aip-agents get ri.foundry.main.agent.abc123 --version 1.0 \
+    --format json --output v1.json
+
+pltr aip-agents get ri.foundry.main.agent.abc123 --version 2.0 \
+    --format json --output v2.json
+
+# Compare with diff
+diff v1.json v2.json
+```

--- a/claude_skill/reference/functions-commands.md
+++ b/claude_skill/reference/functions-commands.md
@@ -1,0 +1,279 @@
+# Functions Commands
+
+Commands for executing Functions queries and inspecting value types in Foundry.
+
+## RID Formats
+- **Query**: `ri.functions.main.query.{uuid}`
+- **Value Type**: `ri.functions.main.value-type.{uuid}`
+
+## Query Commands
+
+### Get Query by API Name
+
+Retrieve query metadata by its API name.
+
+```bash
+pltr functions query get QUERY_API_NAME [OPTIONS]
+
+# Options:
+#   --version, -v TEXT      Query version (e.g., '1.0.0') [default: latest]
+#   --preview               Enable preview mode
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Get latest version of query
+pltr functions query get myQuery
+
+# Get specific version
+pltr functions query get myQuery --version 1.0.0
+
+# Output as JSON
+pltr functions query get myQuery --format json
+
+# Save to file
+pltr functions query get myQuery --format json --output query-info.json
+```
+
+### Get Query by RID
+
+Retrieve query metadata by its Resource Identifier.
+
+```bash
+pltr functions query get-by-rid QUERY_RID [OPTIONS]
+
+# Options:
+#   --version, -v TEXT      Query version (e.g., '1.0.0') [default: latest]
+#   --preview               Enable preview mode
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Get query by RID
+pltr functions query get-by-rid ri.functions.main.query.abc123
+
+# Get specific version
+pltr functions query get-by-rid ri.functions.main.query.abc123 --version 1.0.0
+
+# Output as JSON
+pltr functions query get-by-rid ri.functions.main.query.abc123 --format json
+```
+
+### Execute Query by API Name
+
+Execute a query by its API name with parameters.
+
+```bash
+pltr functions query execute QUERY_API_NAME [OPTIONS]
+
+# Options:
+#   --parameters, -params TEXT  Query parameters as JSON or @file.json
+#   --version, -v TEXT          Query version (e.g., '1.0.0') [default: latest]
+#   --preview                   Enable preview mode
+#   --format, -f TEXT           Output format (table, json, csv)
+#   --output, -o TEXT           Output file path
+#   --profile, -p TEXT          Profile name
+
+# Examples
+
+# Execute with inline parameters
+pltr functions query execute myQuery --parameters '{"limit": 10}'
+
+# Execute with parameters from file
+pltr functions query execute myQuery --parameters @params.json
+
+# Execute with complex parameters
+pltr functions query execute myQuery --parameters '{
+    "limit": 100,
+    "filter": "active",
+    "config": {"enabled": true}
+}'
+
+# Execute specific version
+pltr functions query execute myQuery --version 1.0.0 --parameters '{}'
+
+# Save results to file
+pltr functions query execute myQuery \
+    --parameters '{"limit": 50}' \
+    --output results.json
+```
+
+### Execute Query by RID
+
+Execute a query by its Resource Identifier with parameters.
+
+```bash
+pltr functions query execute-by-rid QUERY_RID [OPTIONS]
+
+# Options:
+#   --parameters, -params TEXT  Query parameters as JSON or @file.json
+#   --version, -v TEXT          Query version (e.g., '1.0.0') [default: latest]
+#   --preview                   Enable preview mode
+#   --format, -f TEXT           Output format (table, json, csv)
+#   --output, -o TEXT           Output file path
+#   --profile, -p TEXT          Profile name
+
+# Examples
+
+# Execute with inline parameters
+pltr functions query execute-by-rid ri.functions.main.query.abc123 \
+    --parameters '{"limit": 10}'
+
+# Execute with parameters from file
+pltr functions query execute-by-rid ri.functions.main.query.abc123 \
+    --parameters @params.json
+
+# Execute specific version
+pltr functions query execute-by-rid ri.functions.main.query.abc123 \
+    --version 1.0.0 \
+    --parameters '{}'
+```
+
+## Value Type Commands
+
+### Get Value Type
+
+Retrieve value type definition and structure information.
+
+```bash
+pltr functions value-type get VALUE_TYPE_RID [OPTIONS]
+
+# Options:
+#   --preview               Enable preview mode
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Get value type details
+pltr functions value-type get ri.functions.main.value-type.xyz
+
+# Output as JSON
+pltr functions value-type get ri.functions.main.value-type.xyz --format json
+
+# Save to file
+pltr functions value-type get ri.functions.main.value-type.xyz \
+    --format json \
+    --output value-type-info.json
+```
+
+## Parameter Types
+
+Functions support various parameter types:
+
+### Primitive Types
+```json
+{
+  "stringParam": "hello",
+  "intParam": 42,
+  "floatParam": 3.14,
+  "boolParam": true
+}
+```
+
+### Array Types
+```json
+{
+  "items": ["a", "b", "c"],
+  "numbers": [1, 2, 3]
+}
+```
+
+### Struct Types
+```json
+{
+  "config": {
+    "enabled": true,
+    "maxRetries": 3,
+    "options": ["fast", "reliable"]
+  }
+}
+```
+
+### Date and Timestamp Types
+```json
+{
+  "startDate": "2024-01-15",
+  "timestamp": 1705363200000
+}
+```
+
+## JSON Input Methods
+
+Parameters can be provided inline or from a file:
+
+```bash
+# Inline JSON
+--parameters '{"key": "value"}'
+
+# File reference (prefix with @)
+--parameters @params.json
+```
+
+## API Name vs RID
+
+Functions can be accessed by either:
+
+| Method | Command | When to Use |
+|--------|---------|-------------|
+| API Name | `execute` / `get` | When you know the query's API name |
+| RID | `execute-by-rid` / `get-by-rid` | When you have the Resource Identifier |
+
+API names are human-readable identifiers assigned to queries, while RIDs are unique system identifiers.
+
+## Versioning
+
+Queries can have multiple versions:
+
+```bash
+# Execute latest version (default)
+pltr functions query execute myQuery --parameters '{}'
+
+# Execute specific version
+pltr functions query execute myQuery --version 1.0.0 --parameters '{}'
+pltr functions query execute myQuery --version 2.1.0 --parameters '{}'
+```
+
+## Common Patterns
+
+### Explore Query Structure Before Execution
+
+```bash
+# First, get query metadata to understand parameters
+pltr functions query get myQuery --format json
+
+# Then execute with appropriate parameters
+pltr functions query execute myQuery --parameters '{"limit": 10}'
+```
+
+### Execute and Process Results
+
+```bash
+# Execute query and save results
+pltr functions query execute myQuery \
+    --parameters '{"filter": "active"}' \
+    --format json \
+    --output results.json
+
+# Process with jq or other tools
+cat results.json | jq '.data | length'
+```
+
+### Parameterized Query with File Input
+
+```bash
+# Create params.json:
+# {
+#   "startDate": "2024-01-01",
+#   "endDate": "2024-01-31",
+#   "status": "completed",
+#   "limit": 1000
+# }
+
+pltr functions query execute monthlyReport --parameters @params.json
+```

--- a/claude_skill/reference/language-models-commands.md
+++ b/claude_skill/reference/language-models-commands.md
@@ -1,0 +1,235 @@
+# Language Models Commands
+
+Commands for interacting with language models (LLMs) in Foundry, including Anthropic Claude models and OpenAI embeddings.
+
+## Model RID Format
+`ri.language-models.main.model.{uuid}`
+
+## Anthropic Claude Commands
+
+### Simple Message (Single-Turn)
+
+Send a single message to an Anthropic Claude model for simple Q&A.
+
+```bash
+pltr language-models anthropic messages MODEL_RID --message "MESSAGE" [OPTIONS]
+
+# Options:
+#   --message, -m TEXT      User message text (required)
+#   --max-tokens INTEGER    Maximum tokens to generate [default: 1024]
+#   --system, -s TEXT       System prompt to guide model behavior
+#   --temperature, -t FLOAT Sampling temperature (0.0-1.0)
+#   --stop TEXT             Stop sequences (can be specified multiple times)
+#   --top-k INTEGER         Sample from top K tokens
+#   --top-p FLOAT           Nucleus sampling threshold (0.0-1.0)
+#   --preview               Enable preview mode
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+pltr language-models anthropic messages ri.language-models.main.model.abc123 \
+    --message "Explain quantum computing"
+
+pltr language-models anthropic messages ri.language-models.main.model.abc123 \
+    --message "Write a haiku" \
+    --system "You are a poetic assistant" \
+    --temperature 0.8 \
+    --max-tokens 100
+
+pltr language-models anthropic messages ri.language-models.main.model.abc123 \
+    --message "List three items" \
+    --stop "." --stop "\n\n"
+
+pltr language-models anthropic messages ri.language-models.main.model.abc123 \
+    --message "Summarize AI trends" \
+    --output response.json
+```
+
+### Advanced Messages (Multi-Turn)
+
+Send complex requests with multi-turn conversations, tool calling, or extended thinking.
+
+```bash
+pltr language-models anthropic messages-advanced MODEL_RID --request REQUEST_JSON [OPTIONS]
+
+# Options:
+#   --request, -r TEXT      Request JSON (inline or @file.json) - required
+#   --preview               Enable preview mode
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Request JSON structure:
+# {
+#   "messages": [...],      # Required: List of message objects
+#   "maxTokens": 1024,      # Required: Maximum tokens to generate
+#   "system": [...],        # Optional: System prompt blocks
+#   "temperature": 0.7,     # Optional: Sampling temperature
+#   "thinking": {...},      # Optional: Extended thinking config
+#   "tools": [...],         # Optional: Tool definitions
+#   "toolChoice": {...},    # Optional: Tool selection strategy
+#   "stopSequences": [...], # Optional: Stop sequences
+#   "topK": 40,             # Optional: Top K sampling
+#   "topP": 0.95            # Optional: Nucleus sampling
+# }
+```
+
+#### Multi-Turn Conversation Example
+
+```bash
+# Create conversation.json:
+# {
+#   "messages": [
+#     {"role": "user", "content": [{"type": "text", "text": "Hi, I need help with Python"}]},
+#     {"role": "assistant", "content": [{"type": "text", "text": "I'd be happy to help! What do you need?"}]},
+#     {"role": "user", "content": [{"type": "text", "text": "How do I read a CSV file?"}]}
+#   ],
+#   "maxTokens": 500
+# }
+
+pltr language-models anthropic messages-advanced ri.language-models.main.model.abc123 \
+    --request @conversation.json
+```
+
+#### Extended Thinking Example
+
+```bash
+pltr language-models anthropic messages-advanced ri.language-models.main.model.abc123 \
+    --request '{"messages": [{"role": "user", "content": [{"type": "text", "text": "Solve this complex problem"}]}], "maxTokens": 2000, "thinking": {"type": "enabled", "budget": 10000}}'
+```
+
+#### Inline with System Prompt
+
+```bash
+pltr language-models anthropic messages-advanced ri.language-models.main.model.abc123 \
+    --request '{"messages": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}], "maxTokens": 100, "system": [{"type": "text", "text": "Be concise"}]}'
+```
+
+## OpenAI Commands
+
+### Generate Embeddings
+
+Generate embedding vectors for text using OpenAI models.
+
+```bash
+pltr language-models openai embeddings MODEL_RID --input INPUT [OPTIONS]
+
+# Options:
+#   --input, -i TEXT        Input text(s) - single string, JSON array, or @file.json (required)
+#   --dimensions, -d INT    Custom embedding dimensions (not all models support this)
+#   --encoding, -e TEXT     Output encoding format: 'float' or 'base64'
+#   --preview               Enable preview mode
+#   --format, -f TEXT       Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Single text
+pltr language-models openai embeddings ri.language-models.main.model.xyz789 \
+    --input "Machine learning is fascinating"
+
+# Multiple texts (inline JSON array)
+pltr language-models openai embeddings ri.language-models.main.model.xyz789 \
+    --input '["Document 1", "Document 2", "Document 3"]'
+
+# Multiple texts from file (texts.json: ["Text 1", "Text 2", "Text 3"])
+pltr language-models openai embeddings ri.language-models.main.model.xyz789 \
+    --input @texts.json
+
+# Custom dimensions and encoding
+pltr language-models openai embeddings ri.language-models.main.model.xyz789 \
+    --input "Sample text" \
+    --dimensions 1024 \
+    --encoding base64
+
+# Save embeddings to file
+pltr language-models openai embeddings ri.language-models.main.model.xyz789 \
+    --input '["Text 1", "Text 2"]' \
+    --output embeddings.json
+```
+
+## Response Format
+
+### Anthropic Response
+
+Responses include token usage information:
+
+```json
+{
+  "content": [
+    {"type": "text", "text": "The response text..."}
+  ],
+  "usage": {
+    "inputTokens": 25,
+    "outputTokens": 150,
+    "totalTokens": 175
+  },
+  "stopReason": "end_turn",
+  "model": "claude-3-sonnet"
+}
+```
+
+Token usage is displayed prominently:
+```
+Token usage - Input: 25, Output: 150, Total: 175
+```
+
+### OpenAI Embeddings Response
+
+```json
+{
+  "data": [
+    {
+      "embedding": [0.0123, -0.0456, ...],
+      "index": 0
+    }
+  ],
+  "usage": {
+    "promptTokens": 8,
+    "totalTokens": 8
+  },
+  "model": "text-embedding-3-small"
+}
+```
+
+## JSON Input Methods
+
+Both inline JSON and file references are supported:
+
+```bash
+# Inline JSON
+--request '{"messages": [...], "maxTokens": 100}'
+
+# File reference (prefix with @)
+--request @request.json
+--input @texts.json
+```
+
+## Common Patterns
+
+### Interactive Chat Session
+
+```bash
+# Save each response and build conversation history
+pltr language-models anthropic messages ri.language-models.main.model.abc123 \
+    --message "Hello!" \
+    --output turn1.json
+
+# Then use messages-advanced for follow-up with full history
+```
+
+### Batch Embeddings for Semantic Search
+
+```bash
+# Generate embeddings for document corpus
+pltr language-models openai embeddings ri.language-models.main.model.xyz789 \
+    --input @documents.json \
+    --output corpus-embeddings.json
+
+# Later: generate embedding for query and compare
+pltr language-models openai embeddings ri.language-models.main.model.xyz789 \
+    --input "search query" \
+    --output query-embedding.json
+```

--- a/claude_skill/reference/models-commands.md
+++ b/claude_skill/reference/models-commands.md
@@ -1,0 +1,232 @@
+# Models Commands
+
+Commands for managing ML models and model versions in the Foundry model registry.
+
+**Note:** This is distinct from the `language-models` module, which handles LLM chat and embeddings operations.
+
+## RID Formats
+- **Model**: `ri.foundry.main.model.{uuid}`
+- **Folder**: `ri.compass.main.folder.{uuid}`
+
+## Model Commands
+
+### Create Model
+
+Create a new ML model in the registry.
+
+```bash
+pltr models model create NAME --folder FOLDER_RID [OPTIONS]
+
+# Options:
+#   --folder, -f TEXT       Parent folder RID (required)
+#   --preview               Enable preview mode
+#   --format TEXT           Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Create a new model
+pltr models model create "fraud-detector" \
+    --folder ri.compass.main.folder.xxx
+
+# Create with JSON output
+pltr models model create "recommendation-engine" \
+    --folder ri.compass.main.folder.xxx \
+    --format json
+
+# Save model info to file
+pltr models model create "anomaly-detector" \
+    --folder ri.compass.main.folder.xxx \
+    --output model-info.json
+```
+
+### Get Model
+
+Get information about a model.
+
+```bash
+pltr models model get MODEL_RID [OPTIONS]
+
+# Options:
+#   --preview               Enable preview mode
+#   --format TEXT           Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Get model details
+pltr models model get ri.foundry.main.model.abc123
+
+# Get as JSON
+pltr models model get ri.foundry.main.model.abc123 --format json
+
+# Save to file
+pltr models model get ri.foundry.main.model.abc123 \
+    --format json \
+    --output model-details.json
+```
+
+## Version Commands
+
+### Get Model Version
+
+Get information about a specific model version.
+
+```bash
+pltr models version get MODEL_RID VERSION_ID [OPTIONS]
+
+# Options:
+#   --preview               Enable preview mode
+#   --format TEXT           Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Get specific version
+pltr models version get ri.foundry.main.model.abc123 v1.0.0
+
+# Get as JSON
+pltr models version get ri.foundry.main.model.abc123 v1.0.0 \
+    --format json
+
+# Save to file
+pltr models version get ri.foundry.main.model.abc123 v1.0.0 \
+    --format json \
+    --output version-details.json
+```
+
+### List Model Versions
+
+List all versions of a model with pagination support.
+
+```bash
+pltr models version list MODEL_RID [OPTIONS]
+
+# Options:
+#   --page-size INTEGER     Maximum versions per page
+#   --page-token TEXT       Token for fetching next page
+#   --preview               Enable preview mode
+#   --format TEXT           Output format (table, json, csv)
+#   --output, -o TEXT       Output file path
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# List all versions
+pltr models version list ri.foundry.main.model.abc123
+
+# List with pagination
+pltr models version list ri.foundry.main.model.abc123 \
+    --page-size 50
+
+# Get next page
+pltr models version list ri.foundry.main.model.abc123 \
+    --page-size 50 \
+    --page-token <token-from-previous-response>
+
+# Save to file
+pltr models version list ri.foundry.main.model.abc123 \
+    --format json \
+    --output versions.json
+```
+
+## SDK Limitations
+
+**No List All Models:** The SDK does not support listing all models in the registry. You must already know the model RID to retrieve it.
+
+To discover models:
+- Use the Foundry web UI
+- Use the Ontology API
+- Maintain your own inventory of model RIDs
+
+## Pagination
+
+The `version list` command supports pagination via tokens:
+
+```bash
+# First page
+pltr models version list ri.foundry.main.model.abc123 --page-size 50
+
+# Output includes nextPageToken if more results exist:
+# Next page available. Use --page-token <token>
+
+# Fetch next page
+pltr models version list ri.foundry.main.model.abc123 \
+    --page-size 50 \
+    --page-token eyJwYWdlIjogMn0=
+```
+
+## Common Patterns
+
+### Create Model and Track Versions
+
+```bash
+# 1. Create the model container
+pltr models model create "my-ml-model" \
+    --folder ri.compass.main.folder.xxx \
+    --format json \
+    --output model-info.json
+
+# 2. Note the model RID from output for future version operations
+cat model-info.json | jq -r '.rid'
+
+# 3. Later: list versions
+pltr models version list ri.foundry.main.model.abc123
+```
+
+### Export Model Metadata
+
+```bash
+# Get model info
+pltr models model get ri.foundry.main.model.abc123 \
+    --format json \
+    --output model.json
+
+# Get all versions
+pltr models version list ri.foundry.main.model.abc123 \
+    --format json \
+    --output versions.json
+```
+
+### Get Latest Version Details
+
+```bash
+# List versions to see what's available
+pltr models version list ri.foundry.main.model.abc123 --format json
+
+# Get details for specific version
+pltr models version get ri.foundry.main.model.abc123 v2.1.0 --format json
+```
+
+### Compare Model Versions
+
+```bash
+# Export two versions for comparison
+pltr models version get ri.foundry.main.model.abc123 v1.0.0 \
+    --format json --output v1.json
+
+pltr models version get ri.foundry.main.model.abc123 v2.0.0 \
+    --format json --output v2.json
+
+# Compare
+diff v1.json v2.json
+```
+
+## Models vs Language-Models
+
+| Module | Purpose | Use Case |
+|--------|---------|----------|
+| `models` | ML model registry | Custom ML models, versioning |
+| `language-models` | LLM interactions | Chat with Claude, embeddings |
+
+```bash
+# ML Model Registry
+pltr models model get ri.foundry.main.model.xxx
+
+# LLM Chat
+pltr language-models anthropic messages ri.language-models.main.model.yyy \
+    --message "Hello"
+```

--- a/claude_skill/reference/streams-commands.md
+++ b/claude_skill/reference/streams-commands.md
@@ -1,0 +1,268 @@
+# Streams Commands
+
+Commands for managing streaming datasets and publishing real-time data records to Foundry.
+
+## Dataset and Stream RID Formats
+- **Dataset**: `ri.foundry.main.dataset.{uuid}`
+- **Folder**: `ri.compass.main.folder.{uuid}`
+
+## Dataset Commands
+
+### Create Streaming Dataset
+
+Create a new streaming dataset with an initial stream.
+
+```bash
+pltr streams dataset create NAME --folder FOLDER_RID --schema SCHEMA [OPTIONS]
+
+# Options:
+#   --folder, -f TEXT       Parent folder RID (required)
+#   --schema, -s TEXT       Stream schema as JSON or @file.json (required)
+#   --branch, -b TEXT       Branch name [default: master]
+#   --compressed            Enable compression
+#   --partitions INTEGER    Number of partitions [default: 1]
+#   --type TEXT             Stream type: HIGH_THROUGHPUT or LOW_LATENCY [default: LOW_LATENCY]
+#   --preview               Enable preview mode
+#   --format TEXT           Output format (table, json, csv)
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Create basic streaming dataset
+pltr streams dataset create my-stream \
+    --folder ri.compass.main.folder.xxx \
+    --schema '{"fieldSchemaList": [{"name": "value", "type": "STRING"}]}'
+
+# Create from schema file with high throughput
+pltr streams dataset create sensor-data \
+    --folder ri.compass.main.folder.xxx \
+    --schema @schema.json \
+    --partitions 5 \
+    --type HIGH_THROUGHPUT
+
+# With specific branch
+pltr streams dataset create my-stream \
+    --folder ri.compass.main.folder.xxx \
+    --schema @schema.json \
+    --branch develop
+```
+
+## Stream Commands
+
+### Create Stream
+
+Create a new stream on a branch of an existing streaming dataset.
+
+```bash
+pltr streams stream create DATASET_RID --branch BRANCH --schema SCHEMA [OPTIONS]
+
+# Options:
+#   --branch, -b TEXT       Branch name to create stream on (required)
+#   --schema, -s TEXT       Stream schema as JSON or @file.json (required)
+#   --compressed            Enable compression
+#   --partitions INTEGER    Number of partitions [default: 1]
+#   --type TEXT             Stream type: HIGH_THROUGHPUT or LOW_LATENCY
+#   --preview               Enable preview mode
+#   --format TEXT           Output format (table, json, csv)
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Create stream on new branch
+pltr streams stream create ri.foundry.main.dataset.xxx \
+    --branch feature-branch \
+    --schema '{"fieldSchemaList": [{"name": "id", "type": "INTEGER"}]}'
+
+# High-throughput stream with multiple partitions
+pltr streams stream create ri.foundry.main.dataset.xxx \
+    --branch production \
+    --schema @schema.json \
+    --partitions 10 \
+    --type HIGH_THROUGHPUT
+```
+
+### Get Stream
+
+Get information about a stream.
+
+```bash
+pltr streams stream get DATASET_RID --branch BRANCH [OPTIONS]
+
+# Options:
+#   --branch, -b TEXT       Stream branch name (required)
+#   --preview               Enable preview mode
+#   --format TEXT           Output format (table, json, csv)
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Get stream on master branch
+pltr streams stream get ri.foundry.main.dataset.xxx --branch master
+
+# Get stream as JSON
+pltr streams stream get ri.foundry.main.dataset.xxx \
+    --branch feature-branch \
+    --format json
+```
+
+### Publish Single Record
+
+Publish a single record to a stream.
+
+```bash
+pltr streams stream publish DATASET_RID --branch BRANCH --record RECORD [OPTIONS]
+
+# Options:
+#   --branch, -b TEXT       Stream branch name (required)
+#   --record, -r TEXT       Record data as JSON or @file.json (required)
+#   --view TEXT             View RID for partitioning
+#   --preview               Enable preview mode
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Publish inline record
+pltr streams stream publish ri.foundry.main.dataset.xxx \
+    --branch master \
+    --record '{"id": 123, "name": "test", "timestamp": 1234567890}'
+
+# Publish from file
+pltr streams stream publish ri.foundry.main.dataset.xxx \
+    --branch master \
+    --record @record.json
+```
+
+### Publish Batch Records
+
+Publish multiple records to a stream in a batch (more efficient than individual publishes).
+
+```bash
+pltr streams stream publish-batch DATASET_RID --branch BRANCH --records RECORDS [OPTIONS]
+
+# Options:
+#   --branch, -b TEXT       Stream branch name (required)
+#   --records, -r TEXT      Records as JSON array or @file.json (required)
+#   --view TEXT             View RID for partitioning
+#   --preview               Enable preview mode
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Publish multiple records inline
+pltr streams stream publish-batch ri.foundry.main.dataset.xxx \
+    --branch master \
+    --records '[{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]'
+
+# Publish from file
+pltr streams stream publish-batch ri.foundry.main.dataset.xxx \
+    --branch master \
+    --records @records.json
+```
+
+### Reset Stream
+
+Reset a stream, clearing all existing data. **Warning: This is irreversible!**
+
+```bash
+pltr streams stream reset DATASET_RID --branch BRANCH [OPTIONS]
+
+# Options:
+#   --branch, -b TEXT       Stream branch name to reset (required)
+#   --confirm               Skip confirmation prompt
+#   --preview               Enable preview mode
+#   --format TEXT           Output format (table, json, csv)
+#   --profile, -p TEXT      Profile name
+
+# Examples
+
+# Reset with confirmation prompt
+pltr streams stream reset ri.foundry.main.dataset.xxx --branch master
+
+# Skip confirmation (use with caution)
+pltr streams stream reset ri.foundry.main.dataset.xxx \
+    --branch master \
+    --confirm
+```
+
+## Schema Format
+
+The schema uses `fieldSchemaList` to define record structure:
+
+```json
+{
+  "fieldSchemaList": [
+    {"name": "id", "type": "INTEGER"},
+    {"name": "name", "type": "STRING"},
+    {"name": "value", "type": "DOUBLE"},
+    {"name": "active", "type": "BOOLEAN"},
+    {"name": "timestamp", "type": "TIMESTAMP"}
+  ]
+}
+```
+
+### Supported Field Types
+- `STRING` - Text data
+- `INTEGER` - 32-bit integer
+- `LONG` - 64-bit integer
+- `DOUBLE` - Floating-point number
+- `BOOLEAN` - True/false
+- `TIMESTAMP` - Unix timestamp
+- `DATE` - Date value
+- `BINARY` - Binary data
+
+## Stream Types
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| `LOW_LATENCY` | Optimized for real-time processing | Interactive dashboards, alerts |
+| `HIGH_THROUGHPUT` | Optimized for volume | Batch ingestion, sensor data |
+
+## Partitioning
+
+- Each partition handles approximately **5 MB/s** of throughput
+- Increase partitions for higher data volumes
+- Default is 1 partition
+
+```bash
+# High-volume stream with 10 partitions
+pltr streams dataset create high-volume-stream \
+    --folder ri.compass.main.folder.xxx \
+    --schema @schema.json \
+    --partitions 10 \
+    --type HIGH_THROUGHPUT
+```
+
+## Common Patterns
+
+### Create and Populate a Stream
+
+```bash
+# 1. Create the streaming dataset
+pltr streams dataset create events \
+    --folder ri.compass.main.folder.xxx \
+    --schema '{"fieldSchemaList": [{"name": "event_id", "type": "STRING"}, {"name": "timestamp", "type": "TIMESTAMP"}, {"name": "data", "type": "STRING"}]}'
+
+# 2. Publish initial records
+pltr streams stream publish-batch ri.foundry.main.dataset.xxx \
+    --branch master \
+    --records @initial-events.json
+```
+
+### Continuous Data Ingestion Script
+
+```bash
+#!/bin/bash
+DATASET_RID="ri.foundry.main.dataset.xxx"
+BRANCH="master"
+
+while true; do
+    # Generate or fetch new records
+    RECORD='{"id": '$RANDOM', "timestamp": '$(date +%s)', "value": '$RANDOM'}'
+
+    pltr streams stream publish "$DATASET_RID" \
+        --branch "$BRANCH" \
+        --record "$RECORD"
+
+    sleep 1
+done
+```


### PR DESCRIPTION
## Summary

- Add reference documentation for 5 new pltr-cli modules merged since v0.11.0
- Update SKILL.md with new version, compatibility info, and quick reference examples

## New Reference Files

| File | Module | Commands |
|------|--------|----------|
| `language-models-commands.md` | language-models | anthropic messages, messages-advanced, openai embeddings |
| `streams-commands.md` | streams | dataset create, stream create/get/publish/publish-batch/reset |
| `functions-commands.md` | functions | query get/get-by-rid/execute/execute-by-rid, value-type get |
| `aip-agents-commands.md` | aip-agents | get, sessions list/get, versions list |
| `models-commands.md` | models | model create/get, version get/list |

## SKILL.md Updates

- Version: 1.0.0 → 1.1.0
- pltr-cli version: 0.11.0+ → 0.12.0+
- SDK version: >= 1.27.0 → >= 1.69.0
- Command count: 80+ → 100+
- Added 5 new modules to Overview section
- Added 5 new rows to Reference Files table
- Added quick reference examples for all new modules

## Test plan

- [x] Verified `pltr language-models --help` shows documented subcommands
- [x] Verified `pltr streams --help` shows documented subcommands
- [x] Verified `pltr functions --help` shows documented subcommands
- [x] Verified `pltr aip-agents --help` shows documented subcommands
- [x] Verified `pltr models --help` shows documented subcommands