### PR TITLE
fix: align ontology SDK params with foundry-platform-sdk 1.69.0

### DIFF
--- a/src/pltr/services/ontology.py
+++ b/src/pltr/services/ontology.py
@@ -184,7 +184,7 @@ class OntologyObjectService(BaseService):
                 ontology_rid,
                 object_type,
                 page_size=page_size,
-                properties=properties,
+                select=properties,
             )
             objects = []
             for obj in result:
@@ -222,7 +222,7 @@ class OntologyObjectService(BaseService):
                 ontology_rid,
                 object_type,
                 page_size=config.page_size or settings.get("page_size", 20),
-                properties=properties,
+                select=properties,
             )
 
             # Use iterator pagination handler
@@ -256,7 +256,7 @@ class OntologyObjectService(BaseService):
         """
         try:
             obj = self.service.OntologyObject.get(
-                ontology_rid, object_type, primary_key, properties=properties
+                ontology_rid, object_type, primary_key, select=properties
             )
             return self._format_object(obj)
         except Exception as e:
@@ -325,7 +325,7 @@ class OntologyObjectService(BaseService):
                 primary_key,
                 link_type,
                 page_size=page_size,
-                properties=properties,
+                select=properties,
             )
             objects = []
             for obj in result:
@@ -355,7 +355,7 @@ class OntologyObjectService(BaseService):
             count = self.service.OntologyObject.count(
                 ontology_rid,
                 object_type,
-                branch_name=branch,
+                branch=branch,
             )
             return {
                 "ontology_rid": ontology_rid,
@@ -395,8 +395,8 @@ class OntologyObjectService(BaseService):
                 object_type,
                 query=query,
                 page_size=page_size,
-                properties=properties,
-                branch_name=branch,
+                select=properties,
+                branch=branch,
             )
             objects = []
             for obj in result:

--- a/tests/test_services/test_ontology.py
+++ b/tests/test_services/test_ontology.py
@@ -347,7 +347,7 @@ def test_count_objects(mock_ontology_object_service):
     assert result["object_type"] == "Employee"
     assert result["branch"] is None
     mock_ontology_object_class.count.assert_called_once_with(
-        "ri.ontology.main.ontology.test", "Employee", branch_name=None
+        "ri.ontology.main.ontology.test", "Employee", branch=None
     )
 
 
@@ -363,7 +363,7 @@ def test_count_objects_with_branch(mock_ontology_object_service):
     assert result["count"] == 24
     assert result["branch"] == "master"
     mock_ontology_object_class.count.assert_called_once_with(
-        "ri.ontology.main.ontology.test", "Employee", branch_name="master"
+        "ri.ontology.main.ontology.test", "Employee", branch="master"
     )
 
 
@@ -384,8 +384,8 @@ def test_search_objects(mock_ontology_object_service, sample_object):
         "Employee",
         query="John",
         page_size=None,
-        properties=None,
-        branch_name=None,
+        select=None,
+        branch=None,
     )
 
 
@@ -409,8 +409,8 @@ def test_search_objects_with_options(mock_ontology_object_service, sample_object
         "Employee",
         query="Jane",
         page_size=10,
-        properties=["name", "department"],
-        branch_name="master",
+        select=["name", "department"],
+        branch="master",
     )
 
 


### PR DESCRIPTION
Fixes #135

The CLI was passing parameter names that don't match the SDK v1.69.0 signatures:

- `branch_name=` → `branch=` in `count_objects` and `search_objects`
- `properties=` → `select=` in `list_objects`, `list_objects_paginated`, `get_object`, `list_linked_objects`, `search_objects`

Tests updated to match.