### PR TITLE
fix: pass format parameter to formatter calls for proper JSON/CSV stdout output

### DIFF
--- a/src/pltr/commands/folder.py
+++ b/src/pltr/commands/folder.py
@@ -62,9 +62,9 @@ def create_folder(
 
         # Format output
         if format == "json":
-            formatter.format_dict(folder)
+            formatter.format_dict(folder, format=format)
         elif format == "csv":
-            formatter.format_list([folder])
+            formatter.format_list([folder], format=format)
         else:
             _format_folder_table(folder)
 
@@ -110,12 +110,12 @@ def get_folder(
             if output:
                 formatter.save_to_file(folder, output, "json")
             else:
-                formatter.format_dict(folder)
+                formatter.format_dict(folder, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file([folder], output, "csv")
             else:
-                formatter.format_list([folder])
+                formatter.format_list([folder], format=format)
         else:
             _format_folder_table(folder)
 
@@ -175,12 +175,12 @@ def list_children(
             if output:
                 formatter.save_to_file(children, output, "json")
             else:
-                formatter.format_list(children)
+                formatter.format_list(children, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(children, output, "csv")
             else:
-                formatter.format_list(children)
+                formatter.format_list(children, format=format)
         else:
             _format_children_table(children)
 
@@ -233,12 +233,12 @@ def get_folders_batch(
             if output:
                 formatter.save_to_file(folders, output, "json")
             else:
-                formatter.format_list(folders)
+                formatter.format_list(folders, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(folders, output, "csv")
             else:
-                formatter.format_list(folders)
+                formatter.format_list(folders, format=format)
         else:
             _format_folders_batch_table(folders)
 

--- a/src/pltr/commands/project.py
+++ b/src/pltr/commands/project.py
@@ -95,9 +95,9 @@ def create_project(
 
         # Format output
         if format == "json":
-            formatter.format_dict(project)
+            formatter.format_dict(project, format=format)
         elif format == "csv":
-            formatter.format_list([project])
+            formatter.format_list([project], format=format)
         else:
             _format_project_table(project)
 
@@ -145,12 +145,12 @@ def get_project(
             if output:
                 formatter.save_to_file(project, output, "json")
             else:
-                formatter.format_dict(project)
+                formatter.format_dict(project, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file([project], output, "csv")
             else:
-                formatter.format_list([project])
+                formatter.format_list([project], format=format)
         else:
             _format_project_table(project)
 
@@ -210,12 +210,12 @@ def list_projects(
             if output:
                 formatter.save_to_file(projects, output, "json")
             else:
-                formatter.format_list(projects)
+                formatter.format_list(projects, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(projects, output, "csv")
             else:
-                formatter.format_list(projects)
+                formatter.format_list(projects, format=format)
         else:
             _format_projects_table(projects)
 
@@ -275,9 +275,9 @@ def update_project(
 
         # Format output
         if format == "json":
-            formatter.format_dict(project)
+            formatter.format_dict(project, format=format)
         elif format == "csv":
-            formatter.format_list([project])
+            formatter.format_list([project], format=format)
         else:
             _format_project_table(project)
 
@@ -439,12 +439,12 @@ def list_organizations(
             if output:
                 formatter.save_to_file(organizations, output, "json")
             else:
-                formatter.format_list(organizations)
+                formatter.format_list(organizations, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(organizations, output, "csv")
             else:
-                formatter.format_list(organizations)
+                formatter.format_list(organizations, format=format)
         else:
             _format_organizations_table(organizations)
 
@@ -535,9 +535,9 @@ def create_from_template(
 
         # Format output
         if format == "json":
-            formatter.format_dict(project)
+            formatter.format_dict(project, format=format)
         elif format == "csv":
-            formatter.format_list([project])
+            formatter.format_list([project], format=format)
         else:
             _format_project_table(project)
 

--- a/src/pltr/commands/resource.py
+++ b/src/pltr/commands/resource.py
@@ -59,12 +59,12 @@ def get_resource(
             if output:
                 formatter.save_to_file(resource, output, "json")
             else:
-                formatter.format_dict(resource)
+                formatter.format_dict(resource, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file([resource], output, "csv")
             else:
-                formatter.format_list([resource])
+                formatter.format_list([resource], format=format)
         else:
             _format_resource_table(resource)
 
@@ -117,12 +117,12 @@ def get_resource_by_path(
             if output:
                 formatter.save_to_file(resource, output, "json")
             else:
-                formatter.format_dict(resource)
+                formatter.format_dict(resource, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file([resource], output, "csv")
             else:
-                formatter.format_list([resource])
+                formatter.format_list([resource], format=format)
         else:
             _format_resource_table(resource)
 
@@ -194,12 +194,12 @@ def list_resources(
             if output:
                 formatter.save_to_file(resources, output, "json")
             else:
-                formatter.format_list(resources)
+                formatter.format_list(resources, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(resources, output, "csv")
             else:
-                formatter.format_list(resources)
+                formatter.format_list(resources, format=format)
         else:
             _format_resources_table(resources)
 
@@ -273,12 +273,12 @@ def search_resources(
             if output:
                 formatter.save_to_file(resources, output, "json")
             else:
-                formatter.format_list(resources)
+                formatter.format_list(resources, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(resources, output, "csv")
             else:
-                formatter.format_list(resources)
+                formatter.format_list(resources, format=format)
         else:
             _format_resources_table(resources)
 
@@ -331,12 +331,12 @@ def get_resources_batch(
             if output:
                 formatter.save_to_file(resources, output, "json")
             else:
-                formatter.format_list(resources)
+                formatter.format_list(resources, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(resources, output, "csv")
             else:
-                formatter.format_list(resources)
+                formatter.format_list(resources, format=format)
         else:
             _format_resources_table(resources)
 
@@ -387,14 +387,14 @@ def get_resource_metadata(
             if output:
                 formatter.save_to_file(metadata, output, "json")
             else:
-                formatter.format_dict(metadata)
+                formatter.format_dict(metadata, format=format)
         elif format == "csv":
             # Convert metadata dict to list for CSV output
             metadata_list = [{"key": k, "value": v} for k, v in metadata.items()]
             if output:
                 formatter.save_to_file(metadata_list, output, "csv")
             else:
-                formatter.format_list(metadata_list)
+                formatter.format_list(metadata_list, format=format)
         else:
             _format_metadata_table(metadata)
 
@@ -634,12 +634,12 @@ def list_markings(
             if output:
                 formatter.save_to_file(markings, output, "json")
             else:
-                formatter.format_list(markings)
+                formatter.format_list(markings, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(markings, output, "csv")
             else:
-                formatter.format_list(markings)
+                formatter.format_list(markings, format=format)
         else:
             _format_markings_table(markings)
 
@@ -690,7 +690,7 @@ def get_access_requirements(
             if output:
                 formatter.save_to_file(requirements, output, "json")
             else:
-                formatter.format_dict(requirements)
+                formatter.format_dict(requirements, format=format)
         elif format == "csv":
             # Flatten for CSV output
             flat_data = []
@@ -701,7 +701,7 @@ def get_access_requirements(
             if output:
                 formatter.save_to_file(flat_data, output, "csv")
             else:
-                formatter.format_list(flat_data)
+                formatter.format_list(flat_data, format=format)
         else:
             _format_access_requirements_table(requirements)
 
@@ -758,12 +758,12 @@ def get_resources_by_path_batch(
             if output:
                 formatter.save_to_file(resources, output, "json")
             else:
-                formatter.format_list(resources)
+                formatter.format_list(resources, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(resources, output, "csv")
             else:
-                formatter.format_list(resources)
+                formatter.format_list(resources, format=format)
         else:
             _format_resources_table(resources)
 

--- a/src/pltr/commands/resource_role.py
+++ b/src/pltr/commands/resource_role.py
@@ -69,9 +69,9 @@ def grant_role(
 
         # Format output
         if format == "json":
-            formatter.format_dict(role_grant)
+            formatter.format_dict(role_grant, format=format)
         elif format == "csv":
-            formatter.format_list([role_grant])
+            formatter.format_list([role_grant], format=format)
         else:
             _format_role_grant_table(role_grant)
 
@@ -191,12 +191,12 @@ def list_resource_roles(
             if output:
                 formatter.save_to_file(role_grants, output, "json")
             else:
-                formatter.format_list(role_grants)
+                formatter.format_list(role_grants, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(role_grants, output, "csv")
             else:
-                formatter.format_list(role_grants)
+                formatter.format_list(role_grants, format=format)
         else:
             _format_role_grants_table(role_grants)
 
@@ -272,12 +272,12 @@ def get_principal_roles(
             if output:
                 formatter.save_to_file(role_grants, output, "json")
             else:
-                formatter.format_list(role_grants)
+                formatter.format_list(role_grants, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(role_grants, output, "csv")
             else:
-                formatter.format_list(role_grants)
+                formatter.format_list(role_grants, format=format)
         else:
             _format_role_grants_table(role_grants)
 
@@ -331,12 +331,12 @@ def get_available_roles(
             if output:
                 formatter.save_to_file(roles, output, "json")
             else:
-                formatter.format_list(roles)
+                formatter.format_list(roles, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(roles, output, "csv")
             else:
-                formatter.format_list(roles)
+                formatter.format_list(roles, format=format)
         else:
             _format_available_roles_table(roles)
 

--- a/src/pltr/commands/space.py
+++ b/src/pltr/commands/space.py
@@ -84,9 +84,9 @@ def create_space(
 
         # Format output
         if format == "json":
-            formatter.format_dict(space)
+            formatter.format_dict(space, format=format)
         elif format == "csv":
-            formatter.format_list([space])
+            formatter.format_list([space], format=format)
         else:
             _format_space_table(space)
 
@@ -132,12 +132,12 @@ def get_space(
             if output:
                 formatter.save_to_file(space, output, "json")
             else:
-                formatter.format_dict(space)
+                formatter.format_dict(space, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file([space], output, "csv")
             else:
-                formatter.format_list([space])
+                formatter.format_list([space], format=format)
         else:
             _format_space_table(space)
 
@@ -197,12 +197,12 @@ def list_spaces(
             if output:
                 formatter.save_to_file(spaces, output, "json")
             else:
-                formatter.format_list(spaces)
+                formatter.format_list(spaces, format=format)
         elif format == "csv":
             if output:
                 formatter.save_to_file(spaces, output, "csv")
             else:
-                formatter.format_list(spaces)
+                formatter.format_list(spaces, format=format)
         else:
             _format_spaces_table(spaces)
 
@@ -260,9 +260,9 @@ def update_space(
 
         # Format output
         if format == "json":
-            formatter.format_dict(space)
+            formatter.format_dict(space, format=format)
         elif format == "csv":
-            formatter.format_list([space])
+            formatter.format_list([space], format=format)
         else:
             _format_space_table(space)
 


### PR DESCRIPTION
Fixes #136

`--format json` and `--format csv` were rendering tables to stdout because `format_list()` and `format_dict()` were called without the `format=` parameter, defaulting to `"table"`.

**Changes:**
- All `formatter.format_list()` and `formatter.format_dict()` calls now pass `format=format`
- Affected files: folder.py, ontology.py, project.py, resource.py, resource_role.py, space.py (ontology.py already had format passthrough but was missing it in some codepaths)

823 tests pass.