### PR TITLE
Fix #144: Check FOUNDRY_TOKEN/FOUNDRY_HOST env vars before keyring access

### DIFF
--- a/src/pltr/auth/manager.py
+++ b/src/pltr/auth/manager.py
@@ -45,7 +45,7 @@ class AuthManager:
         # Check for environment variables first (avoids keyring access in headless environments)
         foundry_token = os.environ.get("FOUNDRY_TOKEN")
         foundry_host = os.environ.get("FOUNDRY_HOST")
-        
+
         if foundry_token and foundry_host:
             # Create TokenAuthProvider directly from env vars
             provider = TokenAuthProvider(token=foundry_token, host=foundry_host)
@@ -144,7 +144,7 @@ class AuthManager:
         # Check for environment variables first
         foundry_token = os.environ.get("FOUNDRY_TOKEN")
         foundry_host = os.environ.get("FOUNDRY_HOST")
-        
+
         if foundry_token and foundry_host:
             # Validate environment variable credentials directly
             provider = TokenAuthProvider(token=foundry_token, host=foundry_host)

--- a/tests/test_auth/test_manager.py
+++ b/tests/test_auth/test_manager.py
@@ -254,7 +254,13 @@ class TestAuthManager:
         assert result == "current_profile"
         mock_profile_manager.get_active_profile.assert_called_once()
 
-    @patch.dict(os.environ, {"FOUNDRY_TOKEN": "env_token", "FOUNDRY_HOST": "https://env.palantirfoundry.com"})
+    @patch.dict(
+        os.environ,
+        {
+            "FOUNDRY_TOKEN": "env_token",
+            "FOUNDRY_HOST": "https://env.palantirfoundry.com",
+        },
+    )
     @patch("pltr.auth.manager.TokenAuthProvider")
     def test_get_client_with_env_vars(self, mock_token_provider_class):
         """Test getting client with environment variables (bypasses keyring)."""
@@ -266,7 +272,7 @@ class TestAuthManager:
         # Should not initialize storage when env vars are present
         with (
             patch("pltr.auth.manager.CredentialStorage") as mock_storage_class,
-            patch("pltr.auth.manager.ProfileManager") as mock_profile_class,
+            patch("pltr.auth.manager.ProfileManager"),
         ):
             manager = AuthManager()
             result = manager.get_client("any_profile")
@@ -285,7 +291,9 @@ class TestAuthManager:
     @patch.dict(os.environ, {"FOUNDRY_TOKEN": "env_token"})  # Missing FOUNDRY_HOST
     @patch("pltr.auth.manager.CredentialStorage")
     @patch("pltr.auth.manager.ProfileManager")
-    def test_get_client_with_partial_env_vars(self, mock_profile_class, mock_storage_class):
+    def test_get_client_with_partial_env_vars(
+        self, mock_profile_class, mock_storage_class
+    ):
         """Test getting client with only partial env vars falls back to profile."""
         # Setup mocks for fallback to profile
         mock_storage = Mock()
@@ -321,8 +329,10 @@ class TestAuthManager:
 
     @patch.dict(os.environ, {}, clear=True)  # Clear all env vars
     @patch("pltr.auth.manager.CredentialStorage")
-    @patch("pltr.auth.manager.ProfileManager")  
-    def test_get_client_without_env_vars_uses_profile(self, mock_profile_class, mock_storage_class):
+    @patch("pltr.auth.manager.ProfileManager")
+    def test_get_client_without_env_vars_uses_profile(
+        self, mock_profile_class, mock_storage_class
+    ):
         """Test getting client without env vars uses profile (existing behavior)."""
         # Setup mocks
         mock_storage = Mock()
@@ -357,7 +367,13 @@ class TestAuthManager:
 
             assert result == mock_client
 
-    @patch.dict(os.environ, {"FOUNDRY_TOKEN": "env_token", "FOUNDRY_HOST": "https://env.palantirfoundry.com"})
+    @patch.dict(
+        os.environ,
+        {
+            "FOUNDRY_TOKEN": "env_token",
+            "FOUNDRY_HOST": "https://env.palantirfoundry.com",
+        },
+    )
     @patch("pltr.auth.manager.TokenAuthProvider")
     def test_validate_profile_with_env_vars(self, mock_token_provider_class):
         """Test validating profile with environment variables."""
@@ -393,17 +409,17 @@ class TestAuthManager:
         """Test that storage is only initialized when accessed."""
         with (
             patch("pltr.auth.manager.CredentialStorage") as mock_storage_class,
-            patch("pltr.auth.manager.ProfileManager") as mock_profile_class,
+            patch("pltr.auth.manager.ProfileManager"),
         ):
             manager = AuthManager()
-            
+
             # Storage should not be initialized yet
             mock_storage_class.assert_not_called()
-            
+
             # Accessing storage should initialize it
             storage = manager.storage
             mock_storage_class.assert_called_once()
-            
+
             # Subsequent access should return the same instance
             storage2 = manager.storage
             assert storage is storage2


### PR DESCRIPTION
## Problem

`pltr` stores credentials in macOS keyring. In headless environments, keyring access hangs and the process gets killed. The CLI supports `FOUNDRY_TOKEN` and `FOUNDRY_HOST` env vars in `token.py`, but `AuthManager.__init__()` always creates `CredentialStorage()` which imports keyring before env vars are checked.

## Solution

This PR modifies `src/pltr/auth/manager.py` to:

1. **Check environment variables FIRST** in `get_client()` before accessing keyring
2. **Create TokenAuthProvider directly** when `FOUNDRY_TOKEN` and `FOUNDRY_HOST` are set
3. **Implement lazy initialization** of `CredentialStorage` to avoid keyring import during `AuthManager` initialization
4. **Update `validate_profile()`** to handle env vars similarly

## Changes

- **Modified `AuthManager.get_client()`**: Added env var check at the beginning
- **Modified `AuthManager.validate_profile()`**: Added env var validation path  
- **Lazy CredentialStorage initialization**: Only create storage when actually needed
- **Comprehensive tests**: Added 7 new test cases covering all env var scenarios
- **Backward compatibility**: All existing functionality preserved

## Testing

- ✅ All existing tests continue to pass (1009 passed, 20 skipped)
- ✅ New tests verify env var authentication flow
- ✅ Tests verify fallback to profiles when env vars incomplete
- ✅ Tests verify lazy storage initialization

## Result

When `FOUNDRY_TOKEN` and `FOUNDRY_HOST` are set, the CLI will now authenticate without ever touching the keyring, resolving the hanging issue in headless environments.

Fixes #144