### PR TITLE
Fix orchestration build search preview mode and pagination

### DIFF
--- a/src/pltr/auth/oauth.py
+++ b/src/pltr/auth/oauth.py
@@ -57,8 +57,12 @@ class OAuthClientProvider(AuthProvider):
         # Newer SDKs may support client-level preview mode while older ones do not.
         # Try the preview-aware constructor first, then fall back for compatibility.
         try:
-            return FoundryClient(auth=auth, hostname=self.host, preview=True)
-        except TypeError:
+            return FoundryClient(  # type: ignore[call-arg]
+                auth=auth, hostname=self.host, preview=True
+            )
+        except TypeError as e:
+            if "preview" not in str(e):
+                raise
             return FoundryClient(auth=auth, hostname=self.host)
 
     def validate(self) -> bool:

--- a/src/pltr/auth/token.py
+++ b/src/pltr/auth/token.py
@@ -35,8 +35,12 @@ class TokenAuthProvider(AuthProvider):
         # Newer SDKs may support client-level preview mode while older ones do not.
         # Try the preview-aware constructor first, then fall back for compatibility.
         try:
-            return FoundryClient(auth=auth, hostname=self.host, preview=True)
-        except TypeError:
+            return FoundryClient(  # type: ignore[call-arg]
+                auth=auth, hostname=self.host, preview=True
+            )
+        except TypeError as e:
+            if "preview" not in str(e):
+                raise
             return FoundryClient(auth=auth, hostname=self.host)
 
     def validate(self) -> bool:

--- a/src/pltr/services/orchestration.py
+++ b/src/pltr/services/orchestration.py
@@ -154,7 +154,7 @@ class OrchestrationService(BaseService):
                 kwargs["page_token"] = page_token
             kwargs.update(search_params)
 
-            response = self.service.Build.search(**kwargs)
+            response = self._search_with_optional_preview(kwargs)
             return self._format_builds_search_response(response)
         except Exception as e:
             raise RuntimeError(f"Failed to search builds: {e}")
@@ -189,7 +189,7 @@ class OrchestrationService(BaseService):
                     kwargs["page_token"] = page_token
                 kwargs.update(search_params)
 
-                response = self.service.Build.search(**kwargs)
+                response = self._search_with_optional_preview(kwargs)
                 formatted = self._format_builds_search_response(response)
                 return {
                     "data": formatted.get("builds", []),
@@ -199,6 +199,22 @@ class OrchestrationService(BaseService):
             return self._paginate_response(fetch_page, config, progress_callback)
         except Exception as e:
             raise RuntimeError(f"Failed to search builds: {e}")
+
+    def _search_with_optional_preview(self, kwargs: Dict[str, Any]) -> Any:
+        """
+        Execute Build.search with preview compatibility fallback.
+
+        Some SDK versions reject the `preview` kwarg at call-time even if preview
+        mode is enabled via client defaults.
+        """
+        try:
+            return self.service.Build.search(**kwargs)
+        except TypeError as e:
+            if "preview" not in str(e):
+                raise
+            fallback_kwargs = dict(kwargs)
+            fallback_kwargs.pop("preview", None)
+            return self.service.Build.search(**fallback_kwargs)
 
     def get_builds_batch(self, build_rids: List[str]) -> Dict[str, Any]:
         """

--- a/tests/test_auth/test_oauth.py
+++ b/tests/test_auth/test_oauth.py
@@ -178,6 +178,36 @@ class TestOAuthClientProvider:
         assert calls[0]["preview"] is True
         assert "preview" not in calls[1]
 
+    def test_get_client_reraises_unrelated_type_error(self, monkeypatch):
+        """Test get_client does not swallow unrelated TypeError failures."""
+
+        class ConfidentialClientAuthStub:
+            def __init__(self, client_id, client_secret, scopes):
+                self.client_id = client_id
+                self.client_secret = client_secret
+                self.scopes = scopes
+
+        class FoundryClientStub:
+            def __init__(self, **kwargs):
+                raise TypeError("bad auth input")
+
+        monkeypatch.setitem(
+            sys.modules,
+            "foundry_sdk",
+            SimpleNamespace(
+                FoundryClient=FoundryClientStub,
+                ConfidentialClientAuth=ConfidentialClientAuthStub,
+            ),
+        )
+
+        provider = OAuthClientProvider(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            host="https://test.palantirfoundry.com",
+        )
+        with pytest.raises(TypeError, match="bad auth input"):
+            provider.get_client()
+
     def test_validate_success(self):
         """Test successful validation."""
         with patch.object(OAuthClientProvider, "get_client") as mock_get_client:

--- a/tests/test_auth/test_token.py
+++ b/tests/test_auth/test_token.py
@@ -138,6 +138,32 @@ class TestTokenAuthProvider:
         assert calls[0]["preview"] is True
         assert "preview" not in calls[1]
 
+    def test_get_client_reraises_unrelated_type_error(self, monkeypatch):
+        """Test get_client does not swallow unrelated TypeError failures."""
+
+        class UserTokenAuthStub:
+            def __init__(self, token):
+                self.token = token
+
+        class FoundryClientStub:
+            def __init__(self, **kwargs):
+                raise TypeError("bad auth input")
+
+        monkeypatch.setitem(
+            sys.modules,
+            "foundry_sdk",
+            SimpleNamespace(
+                FoundryClient=FoundryClientStub,
+                UserTokenAuth=UserTokenAuthStub,
+            ),
+        )
+
+        provider = TokenAuthProvider(
+            token="test_token", host="https://test.palantirfoundry.com"
+        )
+        with pytest.raises(TypeError, match="bad auth input"):
+            provider.get_client()
+
     def test_validate_success(self):
         """Test successful validation."""
         with patch.object(TokenAuthProvider, "get_client") as mock_get_client:

--- a/tests/test_services/test_orchestration.py
+++ b/tests/test_services/test_orchestration.py
@@ -252,6 +252,45 @@ def test_search_builds_paginated_collects_multiple_pages(
     }
 
 
+def test_search_builds_falls_back_when_preview_kwarg_unsupported(
+    mock_orchestration_service, sample_build
+):
+    """Test build search retries without preview when call-level preview is unsupported."""
+    service, mock_build_class, _, _ = mock_orchestration_service
+
+    mock_response = Mock()
+    mock_response.data = [sample_build]
+    mock_response.next_page_token = None
+    mock_build_class.search.side_effect = [
+        TypeError("unexpected keyword argument 'preview'"),
+        mock_response,
+    ]
+
+    result = service.search_builds(page_size=10)
+
+    assert len(result["builds"]) == 1
+    assert mock_build_class.search.call_count == 2
+    assert mock_build_class.search.call_args_list[0].kwargs == {
+        "page_size": 10,
+        "preview": True,
+    }
+    assert mock_build_class.search.call_args_list[1].kwargs == {"page_size": 10}
+
+
+def test_search_builds_reraises_unrelated_type_error(mock_orchestration_service):
+    """Test build search does not swallow unrelated TypeError failures."""
+    service, mock_build_class, _, _ = mock_orchestration_service
+
+    mock_build_class.search.side_effect = TypeError("invalid request body")
+
+    with pytest.raises(
+        RuntimeError, match="Failed to search builds: invalid request body"
+    ):
+        service.search_builds(page_size=10)
+
+    assert mock_build_class.search.call_count == 1
+
+
 def test_get_builds_batch_success(mock_orchestration_service, sample_build):
     """Test successful batch build retrieval."""
     service, mock_build_class, _, _ = mock_orchestration_service


### PR DESCRIPTION
## Summary
- force  on orchestration build search calls
- fix paginated build search response shape so pagination collects build results correctly
- add service-level regression tests for previewed search (single page and paginated)

## Testing
- uv run pytest tests/test_services/test_orchestration.py
- uv run pytest tests/test_commands/test_orchestration.py

Closes #147