### PR TITLE
Fix connectivity connection list for current SDK clients

### DIFF
--- a/src/pltr/services/connectivity.py
+++ b/src/pltr/services/connectivity.py
@@ -56,9 +56,14 @@ class ConnectivityService(BaseService):
             connection_client = self.connections_service.Connection
             if hasattr(connection_client, "list"):
                 connections = connection_client.list()
-            else:
-                connections = self._list_connections_from_filesystem()
-            return [self._format_connection_info(conn) for conn in connections]
+                return [self._format_connection_info(conn) for conn in connections]
+
+            logger.warning(
+                "Connection.list() is unavailable; falling back to filesystem scan. "
+                "Set PLTR_CONNECTIONS_FALLBACK_START_FOLDER_RID to a narrower folder "
+                "if this is slow."
+            )
+            return self._list_connections_from_filesystem()
         except Exception as e:
             raise RuntimeError(f"Failed to list connections: {e}")
 
@@ -448,7 +453,7 @@ class ConnectivityService(BaseService):
             self.DEFAULT_FILESYSTEM_FALLBACK_START_FOLDER_RID,
         )
         pending_folders = deque([start_folder_rid])
-        visited_folders = set()
+        visited_folders: set[str] = set()
         discovered_connections: List[Dict[str, Any]] = []
 
         while pending_folders and len(visited_folders) < self.MAX_FALLBACK_FOLDERS:

--- a/tests/test_services/test_connectivity.py
+++ b/tests/test_services/test_connectivity.py
@@ -140,6 +140,34 @@ class TestConnectivityService:
         assert result[0]["connection_type"] == "connection"
         folder_client.children.assert_any_call("ri.compass.main.folder.0", preview=True)
 
+    def test_list_connections_filesystem_fallback_respects_env_start_folder(
+        self, monkeypatch
+    ):
+        """Test filesystem fallback starts at env-configured folder RID."""
+        monkeypatch.setenv(
+            "PLTR_CONNECTIONS_FALLBACK_START_FOLDER_RID",
+            "ri.compass.main.folder.custom-start",
+        )
+
+        folder_client = Mock()
+        folder_client.children.return_value = []
+
+        connection_client = Mock(spec=["get"])
+        connectivity = SimpleNamespace(Connection=connection_client)
+        filesystem = SimpleNamespace(Folder=folder_client)
+
+        service = ConnectivityService(profile="test")
+        service._client = SimpleNamespace(
+            connectivity=connectivity, filesystem=filesystem
+        )
+
+        result = service.list_connections()
+
+        assert result == []
+        folder_client.children.assert_called_once_with(
+            "ri.compass.main.folder.custom-start", preview=True
+        )
+
     def test_list_connections_filesystem_fallback_requires_filesystem(self):
         """Test filesystem fallback raises when filesystem namespace is unavailable."""
         connection_client = Mock(spec=["get"])
@@ -459,6 +487,24 @@ class TestConnectivityService:
             "errors": [],
         }
         assert result == expected
+
+    def test_looks_like_connection_resource_true_by_rid(self):
+        """Test RID-based connection detection heuristic."""
+        assert ConnectivityService._looks_like_connection_resource(
+            "ri.magritte.main.connection.123", "dataset"
+        )
+
+    def test_looks_like_connection_resource_true_by_type(self):
+        """Test type-based connection detection heuristic."""
+        assert ConnectivityService._looks_like_connection_resource(
+            "ri.compass.main.dataset.123", "connection"
+        )
+
+    def test_looks_like_connection_resource_false_for_folder(self):
+        """Test non-connection resources are not misidentified."""
+        assert not ConnectivityService._looks_like_connection_resource(
+            "ri.compass.main.folder.123", "folder"
+        )
 
     @patch("pltr.services.connectivity.ConnectivityService.client")
     def test_create_connection_success(self, mock_client):


### PR DESCRIPTION
## Summary
- support both legacy (client.connections) and current (client.connectivity) SDK namespaces for connections
- fix connection list so it no longer crashes when Connection.list() is unavailable
- add filesystem-based fallback discovery for connection resources when list is unsupported
- add service tests for modern namespace and fallback behavior

## Testing
- uv run pytest tests/test_services/test_connectivity.py
- uv run pytest tests/test_commands/test_connectivity.py

Closes #148