### PR TITLE
Fix resource list/search without unsupported SDK methods

### DIFF
--- a/src/pltr/services/resource.py
+++ b/src/pltr/services/resource.py
@@ -71,7 +71,7 @@ class ResourceService(BaseService):
         Args:
             folder_rid: Folder Resource Identifier to filter by (optional)
             resource_type: Resource type to filter by (optional)
-            page_size: Number of items per page (optional)
+            page_size: Number of children to request per API page (optional)
             page_token: Pagination token (optional)
 
         Returns:
@@ -79,7 +79,9 @@ class ResourceService(BaseService):
 
         Note:
             Resource type filtering is applied client-side because Folder.children()
-            does not expose a server-side resource type filter.
+            does not expose a server-side resource type filter. When resource_type
+            is provided, each API page can include non-matching resources, so the
+            returned list may contain fewer than page_size items.
         """
         try:
             parent_folder_rid = folder_rid or self.ROOT_FOLDER_RID
@@ -182,7 +184,7 @@ class ResourceService(BaseService):
 
             matches: List[Dict[str, Any]] = []
             pending_folders = deque([start_folder_rid])
-            visited_folders = set()
+            visited_folders: set[str] = set()
 
             while pending_folders and len(visited_folders) < self.MAX_SEARCH_FOLDERS:
                 current_folder_rid = pending_folders.popleft()
@@ -206,8 +208,17 @@ class ResourceService(BaseService):
                         if child_rid and child_rid not in visited_folders:
                             pending_folders.append(child_rid)
 
+            if pending_folders:
+                raise RuntimeError(
+                    "Resource search exceeded folder scan limit "
+                    f"({self.MAX_SEARCH_FOLDERS}). "
+                    "Provide a narrower folder_rid and retry."
+                )
+
             return matches
         except Exception as e:
+            if isinstance(e, RuntimeError):
+                raise
             detail = self._format_error_detail(e)
             raise RuntimeError(f"Failed to search resources: {detail}")
 
@@ -460,7 +471,10 @@ class ResourceService(BaseService):
 
     @staticmethod
     def _is_container_resource(resource: Any) -> bool:
-        """Check whether a resource can have filesystem children."""
+        """Check whether a resource can have filesystem children.
+
+        This list reflects known container resource types returned by filesystem APIs.
+        """
         resource_type = str(getattr(resource, "type", "") or "").lower()
         return resource_type in {"folder", "project", "space", "compass_folder"}
 

--- a/tests/test_services/test_resource.py
+++ b/tests/test_services/test_resource.py
@@ -355,6 +355,27 @@ class TestResourceService:
             resource_service.search_resources("sales", page_token="token123")
         mock_client.filesystem.Folder.children.assert_not_called()
 
+    def test_search_resources_raises_on_folder_scan_limit(
+        self, resource_service, mock_client
+    ):
+        """Test recursive search raises when traversal exceeds folder scan cap."""
+        folder = Mock()
+        folder.rid = "ri.compass.main.folder.123"
+        folder.display_name = "Folder"
+        folder.type = "folder"
+        folder.name = ""
+        folder.description = ""
+        folder.path = ""
+
+        mock_client.filesystem.Folder.children.return_value = [folder]
+        resource_service._client = mock_client
+        resource_service.MAX_SEARCH_FOLDERS = 1
+
+        with pytest.raises(
+            RuntimeError, match="Resource search exceeded folder scan limit"
+        ):
+            resource_service.search_resources("folder")
+
     def test_format_resource_info(self, resource_service):
         """Test formatting resource information."""
         mock_resource = Mock()
@@ -378,6 +399,28 @@ class TestResourceService:
         assert result["created_by"] == "user123"
         assert result["created_time"] == "2023-01-01T00:00:00Z"
         assert result["size_bytes"] == 1024
+
+    def test_format_resource_info_uses_updated_fallback_fields(self, resource_service):
+        """Test formatting falls back to updated_* fields when modified_* fields missing."""
+        mock_resource = Mock()
+        mock_resource.rid = "ri.compass.main.dataset.999"
+        mock_resource.display_name = "Fallback Dataset"
+        mock_resource.name = "fallback_dataset"
+        mock_resource.type = "dataset"
+        mock_resource.folder_rid = "ri.compass.main.folder.456"
+        mock_resource.created_by = "user123"
+        mock_resource.created_time = None
+        mock_resource.modified_by = None
+        mock_resource.updated_by = "user456"
+        mock_resource.modified_time = None
+        mock_resource.updated_time = "2024-01-02T00:00:00Z"
+        mock_resource.size_bytes = 2048
+        mock_resource.trash_status = None
+
+        result = resource_service._format_resource_info(mock_resource)
+
+        assert result["modified_by"] == "user456"
+        assert result["modified_time"] == "2024-01-02T00:00:00Z"
 
     def test_format_metadata_dict(self, resource_service):
         """Test formatting metadata as dict."""


### PR DESCRIPTION
## Summary
- replace unsupported Resource.list()/Resource.search() usage
- implement resource list via Folder.children() from a parent folder (default root)
- implement resource search via bounded folder traversal with query/type filtering
- preserve page_size/page_token behavior on Folder.children() calls
- update resource formatting for updated_by/updated_time fields
- refresh resource service tests for new list/search code paths

## Testing
- uv run pytest tests/test_services/test_resource.py

Closes #150