### PR TITLE
Fix empty error details in folder list failures

### DIFF
--- a/src/pltr/services/folder.py
+++ b/src/pltr/services/folder.py
@@ -37,7 +37,8 @@ class FolderService(BaseService):
             )
             return self._format_folder_info(folder)
         except Exception as e:
-            raise RuntimeError(f"Failed to create folder '{display_name}': {e}")
+            detail = self._format_error_detail(e)
+            raise RuntimeError(f"Failed to create folder '{display_name}': {detail}")
 
     def get_folder(self, folder_rid: str) -> Dict[str, Any]:
         """
@@ -53,7 +54,8 @@ class FolderService(BaseService):
             folder = self.service.Folder.get(folder_rid, preview=True)
             return self._format_folder_info(folder)
         except Exception as e:
-            raise RuntimeError(f"Failed to get folder {folder_rid}: {e}")
+            detail = self._format_error_detail(e)
+            raise RuntimeError(f"Failed to get folder {folder_rid}: {detail}")
 
     def list_children(
         self,
@@ -109,7 +111,8 @@ class FolderService(BaseService):
                 folders.append(self._format_folder_info(folder))
             return folders
         except Exception as e:
-            raise RuntimeError(f"Failed to get folders batch: {e}")
+            detail = self._format_error_detail(e)
+            raise RuntimeError(f"Failed to get folders batch: {detail}")
 
     def _format_folder_info(self, folder: Any) -> Dict[str, Any]:
         """
@@ -183,7 +186,7 @@ class FolderService(BaseService):
 
         args = getattr(error, "args", ())
         if args:
-            joined = " ".join(str(arg) for arg in args if arg)
+            joined = " ".join(str(arg) for arg in args if arg is not None)
             if joined:
                 return joined
 

--- a/tests/test_services/test_folder.py
+++ b/tests/test_services/test_folder.py
@@ -199,6 +199,15 @@ def test_create_folder_error(mock_folder_service):
         service.create_folder("Test Folder", "ri.compass.main.folder.parent")
 
 
+def test_create_folder_error_with_empty_message(mock_folder_service):
+    """Test create folder error handling when exception has no message."""
+    service, mock_folder_class = mock_folder_service
+    mock_folder_class.create.side_effect = Exception()
+
+    with pytest.raises(RuntimeError, match="Failed to create folder .* Exception"):
+        service.create_folder("Test Folder", "ri.compass.main.folder.parent")
+
+
 def test_get_folder_error(mock_folder_service):
     """Test get folder error handling."""
     service, mock_folder_class = mock_folder_service
@@ -226,6 +235,27 @@ def test_list_children_error_with_empty_message(mock_folder_service):
 
     with pytest.raises(RuntimeError, match="Failed to list children .* Exception"):
         service.list_children("ri.compass.main.folder.restricted")
+
+
+def test_get_folders_batch_error_with_empty_message(mock_folder_service):
+    """Test batch get error handling when exception has no message."""
+    service, mock_folder_class = mock_folder_service
+    mock_folder_class.get_batch.side_effect = Exception()
+
+    with pytest.raises(RuntimeError, match="Failed to get folders batch: Exception"):
+        service.get_folders_batch(["ri.compass.main.folder.folder1"])
+
+
+def test_format_error_detail_with_args_fallback(mock_folder_service):
+    """Test error detail uses args when __str__ returns empty."""
+    service, _ = mock_folder_service
+
+    class EmptyStrException(Exception):
+        def __str__(self):
+            return ""
+
+    err = EmptyStrException("some detail")
+    assert service._format_error_detail(err) == "some detail"
 
 
 def test_format_timestamp_none(mock_folder_service):


### PR DESCRIPTION
## Summary
- improve folder list error handling when SDK exceptions stringify to an empty message
- add fallback detail extraction from exception args/class name
- add regression test for empty-message exceptions on folder children listing

## Testing
- uv run pytest tests/test_services/test_folder.py tests/test_commands/test_folder.py

Closes #151