### PR TITLE
Fix issue #163: uppercase role in anthropic messages command

### DIFF
--- a/src/pltr/commands/language_models.py
+++ b/src/pltr/commands/language_models.py
@@ -323,9 +323,9 @@ def anthropic_messages_advanced(
         # conversation.json:
         # {
         #   "messages": [
-        #     {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
-        #     {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
-        #     {"role": "user", "content": [{"type": "text", "text": "Help me"}]}
+        #     {"role": "USER", "content": [{"type": "text", "text": "Hi"}]},
+        #     {"role": "ASSISTANT", "content": [{"type": "text", "text": "Hello!"}]},
+        #     {"role": "USER", "content": [{"type": "text", "text": "Help me"}]}
         #   ],
         #   "maxTokens": 500
         # }
@@ -334,11 +334,11 @@ def anthropic_messages_advanced(
 
         # Inline JSON with system prompt
         pltr language-models anthropic messages-advanced ri.language-models.main.model.abc123 \\
-            --request '{"messages": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}], "maxTokens": 100, "system": [{"type": "text", "text": "Be concise"}]}'
+            --request '{"messages": [{"role": "USER", "content": [{"type": "text", "text": "Hi"}]}], "maxTokens": 100, "system": [{"type": "text", "text": "Be concise"}]}'
 
         # With extended thinking
         pltr language-models anthropic messages-advanced ri.language-models.main.model.abc123 \\
-            --request '{"messages": [{"role": "user", "content": [{"type": "text", "text": "Solve this problem"}]}], "maxTokens": 2000, "thinking": {"type": "enabled", "budget": 10000}}'
+            --request '{"messages": [{"role": "USER", "content": [{"type": "text", "text": "Solve this problem"}]}], "maxTokens": 2000, "thinking": {"type": "enabled", "budget": 10000}}'
     """
     try:
         # Parse request JSON

--- a/src/pltr/services/language_models.py
+++ b/src/pltr/services/language_models.py
@@ -71,7 +71,7 @@ class LanguageModelsService(BaseService):
             # Transform simple message to SDK message format
             messages = [
                 {
-                    "role": "user",
+                    "role": "USER",
                     "content": [{"type": "text", "text": message}],
                 }
             ]

--- a/src/pltr/services/language_models.py
+++ b/src/pltr/services/language_models.py
@@ -134,7 +134,7 @@ class LanguageModelsService(BaseService):
             model_id: Model Resource Identifier
                 Format: ri.language-models.main.model.<id>
             messages: List of message objects with role and content
-                Format: [{"role": "user|assistant", "content": [...]}]
+                Format: [{"role": "USER|ASSISTANT", "content": [...]}]
             max_tokens: Maximum tokens to generate
             system: Optional system prompt blocks
                 Format: [{"type": "text", "text": "..."}]
@@ -162,9 +162,9 @@ class LanguageModelsService(BaseService):
         Example:
             >>> service = LanguageModelsService()
             >>> messages = [
-            ...     {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
-            ...     {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
-            ...     {"role": "user", "content": [{"type": "text", "text": "Help me"}]}
+            ...     {"role": "USER", "content": [{"type": "text", "text": "Hi"}]},
+            ...     {"role": "ASSISTANT", "content": [{"type": "text", "text": "Hello!"}]},
+            ...     {"role": "USER", "content": [{"type": "text", "text": "Help me"}]}
             ... ]
             >>> response = service.send_messages_advanced(
             ...     "ri.language-models.main.model.abc123",
@@ -173,9 +173,17 @@ class LanguageModelsService(BaseService):
             ... )
         """
         try:
+            normalized_messages: List[Dict[str, Any]] = []
+            for msg in messages:
+                normalized_msg = dict(msg)
+                role = normalized_msg.get("role")
+                if isinstance(role, str):
+                    normalized_msg["role"] = role.upper()
+                normalized_messages.append(normalized_msg)
+
             # Build SDK kwargs
             request_kwargs: Dict[str, Any] = {
-                "messages": messages,
+                "messages": normalized_messages,
                 "max_tokens": max_tokens,
                 "preview": preview,
             }

--- a/tests/test_services/test_language_models.py
+++ b/tests/test_services/test_language_models.py
@@ -59,7 +59,7 @@ class TestLanguageModelsService:
         assert "request" not in call_args[1]
         assert call_args[1]["max_tokens"] == 1024
         assert len(call_args[1]["messages"]) == 1
-        assert call_args[1]["messages"][0]["role"] == "user"
+        assert call_args[1]["messages"][0]["role"] == "USER"
         assert call_args[1]["messages"][0]["content"][0]["text"] == message
 
         # Check result

--- a/tests/test_services/test_language_models.py
+++ b/tests/test_services/test_language_models.py
@@ -137,9 +137,9 @@ class TestLanguageModelsService:
         # Setup
         model_id = "ri.language-models.main.model.abc123"
         messages = [
-            {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
-            {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
-            {"role": "user", "content": [{"type": "text", "text": "Help"}]},
+            {"role": "USER", "content": [{"type": "text", "text": "Hi"}]},
+            {"role": "ASSISTANT", "content": [{"type": "text", "text": "Hello!"}]},
+            {"role": "USER", "content": [{"type": "text", "text": "Help"}]},
         ]
         max_tokens = 500
         mock_response = Mock()
@@ -160,11 +160,28 @@ class TestLanguageModelsService:
         assert call_args[1]["preview"] is False
         assert result["role"] == "assistant"
 
+    def test_send_messages_advanced_normalizes_roles(self, service, mock_client):
+        """Test advanced messages role normalization to SDK enum casing."""
+        model_id = "ri.language-models.main.model.abc123"
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
+        ]
+        mock_response = Mock()
+        mock_response.dict.return_value = {"content": [], "role": "assistant"}
+        mock_client.language_models.AnthropicModel.messages.return_value = mock_response
+
+        service.send_messages_advanced(model_id, messages, max_tokens=50)
+
+        call_args = mock_client.language_models.AnthropicModel.messages.call_args
+        assert call_args[1]["messages"][0]["role"] == "USER"
+        assert call_args[1]["messages"][1]["role"] == "ASSISTANT"
+
     def test_send_messages_advanced_with_thinking(self, service, mock_client):
         """Test sending messages with extended thinking."""
         # Setup
         model_id = "ri.language-models.main.model.abc123"
-        messages = [{"role": "user", "content": [{"type": "text", "text": "Solve"}]}]
+        messages = [{"role": "USER", "content": [{"type": "text", "text": "Solve"}]}]
         thinking = {"type": "enabled", "budget": 10000}
         mock_response = Mock()
         mock_response.dict.return_value = {"content": [], "role": "assistant"}
@@ -184,7 +201,7 @@ class TestLanguageModelsService:
         # Setup
         model_id = "ri.language-models.main.model.abc123"
         messages = [
-            {"role": "user", "content": [{"type": "text", "text": "Calculate"}]}
+            {"role": "USER", "content": [{"type": "text", "text": "Calculate"}]}
         ]
         tools = [
             {
@@ -216,7 +233,7 @@ class TestLanguageModelsService:
         """Test error handling in send_messages_advanced."""
         # Setup
         model_id = "ri.language-models.main.model.abc123"
-        messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+        messages = [{"role": "USER", "content": [{"type": "text", "text": "Hi"}]}]
         mock_client.language_models.AnthropicModel.messages.side_effect = Exception(
             "API error"
         )


### PR DESCRIPTION
## Summary
- fix send_message to send Anthropic message role as USER (uppercase)
- keep command behavior unchanged while matching API enum requirements
- update service tests to assert uppercase role payload

## Testing
- uv run pytest tests/test_services/test_language_models.py tests/test_commands/test_language_models.py

Closes #163