### PR TITLE
Add language-models list command (issue #164)

### DIFF
--- a/src/pltr/commands/language_models.py
+++ b/src/pltr/commands/language_models.py
@@ -123,6 +123,56 @@ def display_openai_response(response: dict, format: str, output: Optional[str]):
         formatter.display(response, format)
 
 
+# ===== Shared Language Model Commands =====
+
+
+@app.command("list")
+def list_models(
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        "-p",
+        help="Profile name",
+        autocompletion=complete_profile,
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format (table, json, csv)",
+        autocompletion=complete_output_format,
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+):
+    """List available language models for the current enrollment."""
+    try:
+        from ..services.language_models import LanguageModelsService
+
+        service = LanguageModelsService(profile=profile)
+
+        with SpinnerProgressTracker().track_spinner("Fetching available models..."):
+            models = service.list_available_models()
+
+        formatter.format_table(
+            models,
+            columns=["model_rid", "status", "type", "display_name"],
+            format=format,
+            output=output,
+        )
+
+        if output:
+            formatter.print_success(f"Model list saved to {output}")
+
+    except (ProfileNotFoundError, MissingCredentialsError) as e:
+        formatter.print_error(f"Authentication error: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        formatter.print_error(f"Operation failed: {e}")
+        raise typer.Exit(1)
+
+
 # ===== Anthropic Commands =====
 
 

--- a/src/pltr/services/language_models.py
+++ b/src/pltr/services/language_models.py
@@ -3,7 +3,8 @@ LanguageModels service wrapper for Foundry SDK.
 Provides access to Anthropic Claude models and OpenAI embeddings.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
+import requests
 from .base import BaseService
 
 
@@ -292,6 +293,8 @@ class LanguageModelsService(BaseService):
 
         Tries the platform language-model listing endpoint first, then falls back
         to the provider-compatible OpenAI models endpoint.
+        Note: This currently reads a single response per endpoint and does not
+        follow pagination tokens.
 
         Returns:
             List of model dictionaries with normalized keys:
@@ -308,25 +311,34 @@ class LanguageModelsService(BaseService):
         for endpoint in self._MODEL_LIST_ENDPOINTS:
             try:
                 response = self._make_request("GET", endpoint)
-                payload = response.json() if response.text else {}
-                return self._normalize_model_list(payload, endpoint)
-            except Exception as e:
+            except (requests.HTTPError, RuntimeError) as e:
                 last_error = e
+                continue
+
+            payload = response.json() if response.text else {}
+            return self._normalize_model_list(
+                payload,
+                is_openai_source=("openai/v1/models" in endpoint),
+            )
 
         raise RuntimeError(f"Failed to list available language models: {last_error}")
 
     def _normalize_model_list(
-        self, payload: Dict[str, Any], source_endpoint: str
+        self, payload: Union[Dict[str, Any], List[Any]], is_openai_source: bool = False
     ) -> List[Dict[str, Any]]:
         """Normalize varied model list payloads into a stable CLI schema."""
-        raw_models: Any = []
+        raw_models: List[Any] = []
         if isinstance(payload, dict):
-            raw_models = payload.get("data") or payload.get("models") or []
+            if "data" in payload:
+                data = payload.get("data")
+                if isinstance(data, list):
+                    raw_models = data
+            elif "models" in payload:
+                models = payload.get("models")
+                if isinstance(models, list):
+                    raw_models = models
         elif isinstance(payload, list):
             raw_models = payload
-
-        if not isinstance(raw_models, list):
-            return []
 
         normalized: List[Dict[str, Any]] = []
         for model in raw_models:
@@ -346,7 +358,7 @@ class LanguageModelsService(BaseService):
             status = (
                 model.get("status")
                 or model.get("enrollmentStatus")
-                or ("AVAILABLE" if "openai/v1/models" in source_endpoint else "UNKNOWN")
+                or ("AVAILABLE" if is_openai_source else "UNKNOWN")
             )
 
             model_type = (
@@ -354,7 +366,7 @@ class LanguageModelsService(BaseService):
                 or model.get("provider")
                 or model.get("modelType")
                 or model.get("family")
-                or ("OPENAI" if "openai/v1/models" in source_endpoint else "UNKNOWN")
+                or ("OPENAI" if is_openai_source else "UNKNOWN")
             )
 
             normalized.append(

--- a/src/pltr/services/language_models.py
+++ b/src/pltr/services/language_models.py
@@ -10,6 +10,11 @@ from .base import BaseService
 class LanguageModelsService(BaseService):
     """Service wrapper for Foundry LanguageModels operations."""
 
+    _MODEL_LIST_ENDPOINTS = [
+        "/v2/languageModels",
+        "/api/v2/llm/proxy/openai/v1/models",
+    ]
+
     def _get_service(self) -> Any:
         """Get the Foundry LanguageModels service."""
         return self.client.language_models
@@ -280,3 +285,91 @@ class LanguageModelsService(BaseService):
             raise RuntimeError(
                 f"Failed to generate embeddings with model {model_id}: {e}"
             )
+
+    def list_available_models(self) -> List[Dict[str, Any]]:
+        """
+        List language models available to the authenticated user.
+
+        Tries the platform language-model listing endpoint first, then falls back
+        to the provider-compatible OpenAI models endpoint.
+
+        Returns:
+            List of model dictionaries with normalized keys:
+            - model_rid
+            - status
+            - type
+            - display_name
+
+        Raises:
+            RuntimeError: If no listing endpoint succeeds
+        """
+        last_error: Optional[Exception] = None
+
+        for endpoint in self._MODEL_LIST_ENDPOINTS:
+            try:
+                response = self._make_request("GET", endpoint)
+                payload = response.json() if response.text else {}
+                return self._normalize_model_list(payload, endpoint)
+            except Exception as e:
+                last_error = e
+
+        raise RuntimeError(f"Failed to list available language models: {last_error}")
+
+    def _normalize_model_list(
+        self, payload: Dict[str, Any], source_endpoint: str
+    ) -> List[Dict[str, Any]]:
+        """Normalize varied model list payloads into a stable CLI schema."""
+        raw_models: Any = []
+        if isinstance(payload, dict):
+            raw_models = payload.get("data") or payload.get("models") or []
+        elif isinstance(payload, list):
+            raw_models = payload
+
+        if not isinstance(raw_models, list):
+            return []
+
+        normalized: List[Dict[str, Any]] = []
+        for model in raw_models:
+            if not isinstance(model, dict):
+                continue
+
+            model_id = (
+                model.get("rid")
+                or model.get("modelRid")
+                or model.get("id")
+                or model.get("apiName")
+                or model.get("name")
+            )
+            if not model_id:
+                continue
+
+            status = (
+                model.get("status")
+                or model.get("enrollmentStatus")
+                or ("AVAILABLE" if "openai/v1/models" in source_endpoint else "UNKNOWN")
+            )
+
+            model_type = (
+                model.get("type")
+                or model.get("provider")
+                or model.get("modelType")
+                or model.get("family")
+                or ("OPENAI" if "openai/v1/models" in source_endpoint else "UNKNOWN")
+            )
+
+            normalized.append(
+                {
+                    "model_rid": str(model_id),
+                    "status": str(status),
+                    "type": str(model_type),
+                    "display_name": (
+                        model.get("displayName")
+                        or model.get("name")
+                        or model.get("id")
+                        or str(model_id)
+                    ),
+                }
+            )
+
+        normalized.sort(key=lambda item: item["model_rid"])
+        return normalized

--- a/src/pltr/services/language_models.py
+++ b/src/pltr/services/language_models.py
@@ -311,7 +311,7 @@ class LanguageModelsService(BaseService):
         for endpoint in self._MODEL_LIST_ENDPOINTS:
             try:
                 response = self._make_request("GET", endpoint)
-            except (requests.HTTPError, RuntimeError) as e:
+            except (requests.RequestException, RuntimeError) as e:
                 last_error = e
                 continue
 

--- a/tests/test_commands/test_language_models.py
+++ b/tests/test_commands/test_language_models.py
@@ -25,6 +25,25 @@ class TestLanguageModelsCommands:
             MockService.return_value = mock_svc
             yield mock_svc
 
+    def test_language_models_list_success(self, runner, mock_service):
+        """Test successful language-models list command."""
+        mock_service.list_available_models.return_value = [
+            {
+                "model_rid": "ri.language-model-service..language-model.anthropic_claude_3_5_sonnet_v2",
+                "status": "ENROLLED",
+                "type": "ANTHROPIC",
+                "display_name": "Claude 3.5 Sonnet",
+            }
+        ]
+
+        result = runner.invoke(
+            app,
+            ["language-models", "list", "--format", "json"],
+        )
+
+        assert result.exit_code == 0
+        mock_service.list_available_models.assert_called_once()
+
     # ===== Anthropic Messages Tests =====
 
     def test_anthropic_messages_success(self, runner, mock_service):

--- a/tests/test_commands/test_language_models.py
+++ b/tests/test_commands/test_language_models.py
@@ -43,6 +43,71 @@ class TestLanguageModelsCommands:
 
         assert result.exit_code == 0
         mock_service.list_available_models.assert_called_once()
+        assert "model_rid" in result.output
+        assert "anthropic_claude_3_5_sonnet_v2" in result.output
+
+    def test_language_models_list_auth_error(self, runner, mock_service):
+        """Test list command with authentication error."""
+        from pltr.auth.base import ProfileNotFoundError
+
+        mock_service.list_available_models.side_effect = ProfileNotFoundError(
+            "Profile not found"
+        )
+
+        result = runner.invoke(app, ["language-models", "list"])
+
+        assert result.exit_code == 1
+        assert "Authentication error" in result.output
+
+    def test_language_models_list_missing_credentials_error(self, runner, mock_service):
+        """Test list command with missing credentials."""
+        from pltr.auth.base import MissingCredentialsError
+
+        mock_service.list_available_models.side_effect = MissingCredentialsError(
+            "Missing credentials"
+        )
+
+        result = runner.invoke(app, ["language-models", "list"])
+
+        assert result.exit_code == 1
+        assert "Authentication error" in result.output
+
+    def test_language_models_list_runtime_error(self, runner, mock_service):
+        """Test list command with service runtime error."""
+        mock_service.list_available_models.side_effect = RuntimeError("boom")
+
+        result = runner.invoke(app, ["language-models", "list"])
+
+        assert result.exit_code == 1
+        assert "Operation failed" in result.output
+
+    def test_language_models_list_output_file(self, runner, mock_service, tmp_path):
+        """Test list command with --output file flag."""
+        output_path = tmp_path / "models.json"
+        mock_service.list_available_models.return_value = [
+            {
+                "model_rid": "ri.language-model-service..language-model.example",
+                "status": "ENROLLED",
+                "type": "ANTHROPIC",
+                "display_name": "Example",
+            }
+        ]
+
+        result = runner.invoke(
+            app,
+            [
+                "language-models",
+                "list",
+                "--format",
+                "json",
+                "--output",
+                str(output_path),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Model list saved to" in result.output
+        assert output_path.exists()
 
     # ===== Anthropic Messages Tests =====
 

--- a/tests/test_services/test_language_models.py
+++ b/tests/test_services/test_language_models.py
@@ -1,6 +1,7 @@
 """Tests for LanguageModels service."""
 
 import pytest
+import requests
 from unittest.mock import Mock, patch
 from pltr.services.language_models import LanguageModelsService
 
@@ -284,6 +285,26 @@ class TestLanguageModelsService:
         assert mock_req.call_count == 2
         assert mock_req.call_args_list[0].args == ("GET", "/v2/languageModels")
         assert mock_req.call_args_list[1].args == (
+            "GET",
+            "/api/v2/llm/proxy/openai/v1/models",
+        )
+
+    def test_list_available_models_connection_error_fallback(self, service):
+        """Test fallback when the first endpoint fails with network error."""
+        fallback_response = Mock()
+        fallback_response.text = "ok"
+        fallback_response.json.return_value = {"data": [{"id": "gpt-4.1"}]}
+
+        with patch.object(
+            service,
+            "_make_request",
+            side_effect=[requests.ConnectionError("network down"), fallback_response],
+        ) as mock_req:
+            result = service.list_available_models()
+
+        assert len(result) == 1
+        assert result[0]["model_rid"] == "gpt-4.1"
+        assert mock_req.call_args_list[-1].args == (
             "GET",
             "/api/v2/llm/proxy/openai/v1/models",
         )

--- a/tests/test_services/test_language_models.py
+++ b/tests/test_services/test_language_models.py
@@ -243,7 +243,9 @@ class TestLanguageModelsService:
             ]
         }
 
-        with patch.object(service, "_make_request", return_value=mock_response) as mock_req:
+        with patch.object(
+            service, "_make_request", return_value=mock_response
+        ) as mock_req:
             result = service.list_available_models()
 
         assert len(result) == 1

--- a/tests/test_services/test_language_models.py
+++ b/tests/test_services/test_language_models.py
@@ -288,6 +288,37 @@ class TestLanguageModelsService:
             "/api/v2/llm/proxy/openai/v1/models",
         )
 
+    def test_list_available_models_prefers_explicit_empty_data(self, service):
+        """Test that an explicit empty `data` list does not fall back to `models`."""
+        mock_response = Mock()
+        mock_response.text = "ok"
+        mock_response.json.return_value = {
+            "data": [],
+            "models": [{"id": "should-not-be-used"}],
+        }
+
+        with patch.object(
+            service, "_make_request", return_value=mock_response
+        ) as mock_req:
+            result = service.list_available_models()
+
+        assert result == []
+        mock_req.assert_called_once_with("GET", "/v2/languageModels")
+
+    def test_list_available_models_json_error_not_swallowed(self, service):
+        """Test that JSON parsing errors are surfaced and do not trigger fallback."""
+        bad_response = Mock()
+        bad_response.text = "not-json"
+        bad_response.json.side_effect = ValueError("invalid json")
+
+        with patch.object(
+            service, "_make_request", return_value=bad_response
+        ) as mock_req:
+            with pytest.raises(ValueError, match="invalid json"):
+                service.list_available_models()
+
+        mock_req.assert_called_once_with("GET", "/v2/languageModels")
+
     def test_list_available_models_error(self, service):
         """Test error handling when all model listing endpoints fail."""
         with patch.object(

--- a/tests/test_services/test_language_models.py
+++ b/tests/test_services/test_language_models.py
@@ -226,6 +226,76 @@ class TestLanguageModelsService:
             service.send_messages_advanced(model_id, messages, max_tokens=100)
         assert "Failed to send messages" in str(exc_info.value)
 
+    # ===== Language Model Discovery Tests =====
+
+    def test_list_available_models_v2_endpoint(self, service):
+        """Test listing models from native language models endpoint."""
+        mock_response = Mock()
+        mock_response.text = "ok"
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "rid": "ri.language-model-service..language-model.anthropic_claude_3_5_sonnet_v2",
+                    "status": "ENROLLED",
+                    "provider": "ANTHROPIC",
+                    "displayName": "Claude 3.5 Sonnet",
+                }
+            ]
+        }
+
+        with patch.object(service, "_make_request", return_value=mock_response) as mock_req:
+            result = service.list_available_models()
+
+        assert len(result) == 1
+        assert (
+            result[0]["model_rid"]
+            == "ri.language-model-service..language-model.anthropic_claude_3_5_sonnet_v2"
+        )
+        assert result[0]["status"] == "ENROLLED"
+        assert result[0]["type"] == "ANTHROPIC"
+        mock_req.assert_called_once_with("GET", "/v2/languageModels")
+
+    def test_list_available_models_openai_proxy_fallback(self, service):
+        """Test fallback to provider-compatible OpenAI models endpoint."""
+        fallback_response = Mock()
+        fallback_response.text = "ok"
+        fallback_response.json.return_value = {
+            "data": [
+                {
+                    "id": "gpt-4o",
+                    "object": "model",
+                }
+            ]
+        }
+
+        with patch.object(
+            service,
+            "_make_request",
+            side_effect=[RuntimeError("404"), fallback_response],
+        ) as mock_req:
+            result = service.list_available_models()
+
+        assert len(result) == 1
+        assert result[0]["model_rid"] == "gpt-4o"
+        assert result[0]["status"] == "AVAILABLE"
+        assert result[0]["type"] == "OPENAI"
+        assert mock_req.call_count == 2
+        assert mock_req.call_args_list[0].args == ("GET", "/v2/languageModels")
+        assert mock_req.call_args_list[1].args == (
+            "GET",
+            "/api/v2/llm/proxy/openai/v1/models",
+        )
+
+    def test_list_available_models_error(self, service):
+        """Test error handling when all model listing endpoints fail."""
+        with patch.object(
+            service, "_make_request", side_effect=RuntimeError("unavailable")
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                service.list_available_models()
+
+        assert "Failed to list available language models" in str(exc_info.value)
+
     # ===== OpenAI Embeddings Tests =====
 
     def test_generate_embeddings_single_text(self, service, mock_client):


### PR DESCRIPTION
## Summary
- add new language-models list command
- add LanguageModelsService list_available_models with endpoint fallback
- normalize output fields to model_rid, status, type, display_name
- add command and service tests for success, fallback, and error handling

## Testing
- uv run pytest tests/test_services/test_language_models.py tests/test_commands/test_language_models.py

Closes #164