### PR TITLE
Add language-models enroll/status commands (issue #165)

### DIFF
--- a/src/pltr/commands/language_models.py
+++ b/src/pltr/commands/language_models.py
@@ -173,6 +173,98 @@ def list_models(
         raise typer.Exit(1)
 
 
+@app.command("status")
+def model_status(
+    model_id: str = typer.Argument(
+        ...,
+        help="Model Resource Identifier (ri.language-model-service..language-model.<id>)",
+    ),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        "-p",
+        help="Profile name",
+        autocompletion=complete_profile,
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format (table, json, csv)",
+        autocompletion=complete_output_format,
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+):
+    """Check enrollment status for a language model."""
+    try:
+        from ..services.language_models import LanguageModelsService
+
+        service = LanguageModelsService(profile=profile)
+
+        with SpinnerProgressTracker().track_spinner("Checking model status..."):
+            result = service.get_model_enrollment_status(model_id)
+
+        formatter.format_dict(result, format=format, output=output)
+
+        if output:
+            formatter.print_success(f"Model status saved to {output}")
+
+    except (ProfileNotFoundError, MissingCredentialsError) as e:
+        formatter.print_error(f"Authentication error: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        formatter.print_error(f"Operation failed: {e}")
+        raise typer.Exit(1)
+
+
+@app.command("enroll")
+def enroll_model(
+    model_id: str = typer.Argument(
+        ...,
+        help="Model Resource Identifier (ri.language-model-service..language-model.<id>)",
+    ),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        "-p",
+        help="Profile name",
+        autocompletion=complete_profile,
+    ),
+    format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format (table, json, csv)",
+        autocompletion=complete_output_format,
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+):
+    """Enroll/enable a language model for API usage."""
+    try:
+        from ..services.language_models import LanguageModelsService
+
+        service = LanguageModelsService(profile=profile)
+
+        with SpinnerProgressTracker().track_spinner("Enrolling model..."):
+            result = service.enroll_model(model_id)
+
+        formatter.format_dict(result, format=format, output=output)
+
+        if output:
+            formatter.print_success(f"Enrollment result saved to {output}")
+
+    except (ProfileNotFoundError, MissingCredentialsError) as e:
+        formatter.print_error(f"Authentication error: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        formatter.print_error(f"Operation failed: {e}")
+        raise typer.Exit(1)
+
+
 # ===== Anthropic Commands =====
 
 

--- a/src/pltr/commands/language_models.py
+++ b/src/pltr/commands/language_models.py
@@ -197,7 +197,7 @@ def model_status(
         None, "--output", "-o", help="Output file path"
     ),
 ):
-    """Check enrollment status for a language model."""
+    """Check enrollment status for a language model via direct API fallback endpoints."""
     try:
         from ..services.language_models import LanguageModelsService
 
@@ -243,7 +243,7 @@ def enroll_model(
         None, "--output", "-o", help="Output file path"
     ),
 ):
-    """Enroll/enable a language model for API usage."""
+    """Enroll/enable a language model via direct API fallback endpoints."""
     try:
         from ..services.language_models import LanguageModelsService
 

--- a/src/pltr/services/language_models.py
+++ b/src/pltr/services/language_models.py
@@ -4,6 +4,7 @@ Provides access to Anthropic Claude models and OpenAI embeddings.
 """
 
 from typing import Any, Dict, List, Optional, Union
+import json
 import requests
 from urllib.parse import quote
 from .base import BaseService
@@ -426,7 +427,11 @@ class LanguageModelsService(BaseService):
                 response = self._make_request("GET", endpoint)
                 payload = response.json() if response.text else {}
                 return self._normalize_single_model_status(model_id, payload)
-            except (requests.RequestException, RuntimeError, ValueError) as e:
+            except (
+                requests.RequestException,
+                RuntimeError,
+                json.JSONDecodeError,
+            ) as e:
                 last_error = e
                 continue
 
@@ -434,7 +439,11 @@ class LanguageModelsService(BaseService):
         try:
             response = self._make_request("GET", "/api/v2/llm/proxy/openai/v1/models")
             payload = response.json() if response.text else {}
-        except (requests.RequestException, RuntimeError, ValueError) as fallback_error:
+        except (
+            requests.RequestException,
+            RuntimeError,
+            json.JSONDecodeError,
+        ) as fallback_error:
             raise RuntimeError(
                 f"Failed to get model enrollment status for {model_id}. "
                 f"Primary endpoint error: {last_error}. "
@@ -446,7 +455,7 @@ class LanguageModelsService(BaseService):
                 return self._normalize_single_model_status(
                     model_id,
                     item,
-                    default_status="AVAILABLE",
+                    default_status="AVAILABLE_VIA_PROXY",
                     default_type="OPENAI",
                     default_display_name=model_id,
                 )
@@ -481,7 +490,11 @@ class LanguageModelsService(BaseService):
                 return self._normalize_single_model_status(
                     model_id, payload, default_status="ENROLLED"
                 )
-            except (requests.RequestException, RuntimeError, ValueError) as e:
+            except (
+                requests.RequestException,
+                RuntimeError,
+                json.JSONDecodeError,
+            ) as e:
                 last_error = e
                 continue
 

--- a/src/pltr/services/language_models.py
+++ b/src/pltr/services/language_models.py
@@ -6,7 +6,6 @@ Provides access to Anthropic Claude models and OpenAI embeddings.
 from typing import Any, Dict, List, Optional, Union
 import requests
 from urllib.parse import quote
-import requests
 from .base import BaseService
 
 

--- a/src/pltr/services/language_models.py
+++ b/src/pltr/services/language_models.py
@@ -5,6 +5,7 @@ Provides access to Anthropic Claude models and OpenAI embeddings.
 
 from typing import Any, Dict, List, Optional, Union
 import requests
+from urllib.parse import quote
 from .base import BaseService
 
 
@@ -14,6 +15,14 @@ class LanguageModelsService(BaseService):
     _MODEL_LIST_ENDPOINTS = [
         "/v2/languageModels",
         "/api/v2/llm/proxy/openai/v1/models",
+    ]
+    _MODEL_STATUS_ENDPOINTS = [
+        "/v2/languageModels/{model_id}",
+        "/api/v2/llm/models/{model_id}",
+    ]
+    _MODEL_ENROLL_ENDPOINTS = [
+        "/v2/languageModels/{model_id}/enroll",
+        "/api/v2/llm/models/{model_id}/enroll",
     ]
 
     def _get_service(self) -> Any:
@@ -393,3 +402,133 @@ class LanguageModelsService(BaseService):
 
         normalized.sort(key=lambda item: item["model_rid"])
         return normalized
+
+    def get_model_enrollment_status(self, model_id: str) -> Dict[str, Any]:
+        """
+        Get enrollment status for a language model.
+
+        Args:
+            model_id: Model RID or API name
+
+        Returns:
+            Dictionary with normalized keys:
+            - model_rid
+            - status
+            - type
+            - display_name
+        """
+        encoded_model_id = quote(model_id, safe="")
+        last_error: Optional[Exception] = None
+
+        for endpoint_template in self._MODEL_STATUS_ENDPOINTS:
+            endpoint = endpoint_template.format(model_id=encoded_model_id)
+            try:
+                response = self._make_request("GET", endpoint)
+                payload = response.json() if response.text else {}
+                return self._normalize_single_model_status(model_id, payload)
+            except (requests.RequestException, RuntimeError, ValueError) as e:
+                last_error = e
+                continue
+
+        # Fallback: infer availability from provider-compatible OpenAI models list.
+        try:
+            response = self._make_request("GET", "/api/v2/llm/proxy/openai/v1/models")
+            payload = response.json() if response.text else {}
+        except (requests.RequestException, RuntimeError, ValueError) as fallback_error:
+            raise RuntimeError(
+                f"Failed to get model enrollment status for {model_id}. "
+                f"Primary endpoint error: {last_error}. "
+                f"Fallback endpoint error: {fallback_error}"
+            )
+
+        for item in payload.get("data", []) if isinstance(payload, dict) else []:
+            if isinstance(item, dict) and item.get("id") == model_id:
+                return self._normalize_single_model_status(
+                    model_id,
+                    item,
+                    default_status="AVAILABLE",
+                    default_type="OPENAI",
+                    default_display_name=model_id,
+                )
+
+        raise RuntimeError(
+            f"Model '{model_id}' not found via any known endpoint. "
+            f"Last primary endpoint error: {last_error}"
+        )
+
+    def enroll_model(self, model_id: str) -> Dict[str, Any]:
+        """
+        Enroll or enable a language model for API usage.
+
+        Args:
+            model_id: Model RID or API name
+
+        Returns:
+            Enrollment result dictionary with normalized keys:
+            - model_rid
+            - status
+            - type
+            - display_name
+        """
+        encoded_model_id = quote(model_id, safe="")
+        last_error: Optional[Exception] = None
+
+        for endpoint_template in self._MODEL_ENROLL_ENDPOINTS:
+            endpoint = endpoint_template.format(model_id=encoded_model_id)
+            try:
+                response = self._make_request("POST", endpoint, json_data={})
+                payload = response.json() if response.text else {}
+                return self._normalize_single_model_status(
+                    model_id, payload, default_status="ENROLLED"
+                )
+            except (requests.RequestException, RuntimeError, ValueError) as e:
+                last_error = e
+                continue
+
+        raise RuntimeError(
+            f"Failed to enroll model {model_id}. "
+            f"Enrollment may require Model Catalog UI access for this model: {last_error}"
+        )
+
+    def _normalize_single_model_status(
+        self,
+        model_id: str,
+        payload: Dict[str, Any],
+        default_status: str = "UNKNOWN",
+        default_type: str = "UNKNOWN",
+        default_display_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Normalize status payloads from varying endpoints."""
+        model_data = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(model_data, dict):
+            payload = model_data
+
+        if not isinstance(payload, dict):
+            payload = {}
+
+        return {
+            "model_rid": str(
+                payload.get("rid")
+                or payload.get("modelRid")
+                or payload.get("id")
+                or model_id
+            ),
+            "status": str(
+                payload.get("status")
+                or payload.get("enrollmentStatus")
+                or default_status
+            ),
+            "type": str(
+                payload.get("type")
+                or payload.get("provider")
+                or payload.get("modelType")
+                or default_type
+            ),
+            "display_name": str(
+                payload.get("displayName")
+                or payload.get("name")
+                or payload.get("id")
+                or default_display_name
+                or model_id
+            ),
+        }

--- a/src/pltr/services/language_models.py
+++ b/src/pltr/services/language_models.py
@@ -6,6 +6,7 @@ Provides access to Anthropic Claude models and OpenAI embeddings.
 from typing import Any, Dict, List, Optional, Union
 import requests
 from urllib.parse import quote
+import requests
 from .base import BaseService
 
 

--- a/tests/test_commands/test_language_models.py
+++ b/tests/test_commands/test_language_models.py
@@ -109,6 +109,98 @@ class TestLanguageModelsCommands:
         assert "Model list saved to" in result.output
         assert output_path.exists()
 
+    def test_language_models_status_success(self, runner, mock_service):
+        """Test successful language-models status command."""
+        model_id = (
+            "ri.language-model-service..language-model.anthropic_claude_3_5_sonnet_v2"
+        )
+        mock_service.get_model_enrollment_status.return_value = {
+            "model_rid": model_id,
+            "status": "ENROLLED",
+            "type": "ANTHROPIC",
+            "display_name": "Claude 3.5 Sonnet",
+        }
+
+        result = runner.invoke(
+            app,
+            ["language-models", "status", model_id, "--format", "json"],
+        )
+
+        assert result.exit_code == 0
+        mock_service.get_model_enrollment_status.assert_called_once_with(model_id)
+        assert "model_rid" in result.output
+        assert "anthropic_claude_3_5_sonnet_v2" in result.output
+
+    def test_language_models_enroll_success(self, runner, mock_service):
+        """Test successful language-models enroll command."""
+        model_id = (
+            "ri.language-model-service..language-model.anthropic_claude_3_5_sonnet_v2"
+        )
+        mock_service.enroll_model.return_value = {
+            "model_rid": model_id,
+            "status": "ENROLLED",
+            "type": "ANTHROPIC",
+            "display_name": "Claude 3.5 Sonnet",
+        }
+
+        result = runner.invoke(
+            app,
+            ["language-models", "enroll", model_id, "--format", "json"],
+        )
+
+        assert result.exit_code == 0
+        mock_service.enroll_model.assert_called_once_with(model_id)
+        assert "model_rid" in result.output
+        assert "anthropic_claude_3_5_sonnet_v2" in result.output
+
+    def test_language_models_status_auth_error(self, runner, mock_service):
+        """Test status command with auth error."""
+        from pltr.auth.base import ProfileNotFoundError
+
+        model_id = "ri.language-model-service..language-model.example"
+        mock_service.get_model_enrollment_status.side_effect = ProfileNotFoundError(
+            "Profile not found"
+        )
+
+        result = runner.invoke(app, ["language-models", "status", model_id])
+
+        assert result.exit_code == 1
+        assert "Authentication error" in result.output
+
+    def test_language_models_status_runtime_error(self, runner, mock_service):
+        """Test status command with runtime error."""
+        model_id = "ri.language-model-service..language-model.example"
+        mock_service.get_model_enrollment_status.side_effect = RuntimeError("boom")
+
+        result = runner.invoke(app, ["language-models", "status", model_id])
+
+        assert result.exit_code == 1
+        assert "Operation failed" in result.output
+
+    def test_language_models_enroll_auth_error(self, runner, mock_service):
+        """Test enroll command with auth error."""
+        from pltr.auth.base import MissingCredentialsError
+
+        model_id = "ri.language-model-service..language-model.example"
+        mock_service.enroll_model.side_effect = MissingCredentialsError(
+            "Missing credentials"
+        )
+
+        result = runner.invoke(app, ["language-models", "enroll", model_id])
+
+        assert result.exit_code == 1
+        assert "Authentication error" in result.output
+
+    def test_language_models_enroll_runtime_error(self, runner, mock_service):
+        """Test enroll command with runtime error."""
+        model_id = "ri.language-model-service..language-model.example"
+        mock_service.enroll_model.side_effect = RuntimeError("boom")
+
+        result = runner.invoke(app, ["language-models", "enroll", model_id])
+
+        assert result.exit_code == 1
+        assert "Operation failed" in result.output
+
     # ===== Anthropic Messages Tests =====
 
     def test_anthropic_messages_success(self, runner, mock_service):

--- a/tests/test_services/test_language_models.py
+++ b/tests/test_services/test_language_models.py
@@ -367,6 +367,192 @@ class TestLanguageModelsService:
 
         assert "Failed to list available language models" in str(exc_info.value)
 
+    # ===== Enrollment/Status Tests =====
+
+    def test_get_model_enrollment_status(self, service):
+        """Test getting model enrollment status."""
+        model_id = (
+            "ri.language-model-service..language-model.anthropic_claude_3_5_sonnet_v2"
+        )
+        mock_response = Mock()
+        mock_response.text = "ok"
+        mock_response.json.return_value = {
+            "rid": model_id,
+            "status": "ENROLLED",
+            "provider": "ANTHROPIC",
+            "displayName": "Claude 3.5 Sonnet",
+        }
+
+        with patch.object(
+            service, "_make_request", return_value=mock_response
+        ) as mock_req:
+            result = service.get_model_enrollment_status(model_id)
+
+        assert result["model_rid"] == model_id
+        assert result["status"] == "ENROLLED"
+        assert result["type"] == "ANTHROPIC"
+        mock_req.assert_called_once_with(
+            "GET",
+            "/v2/languageModels/ri.language-model-service..language-model.anthropic_claude_3_5_sonnet_v2",
+        )
+
+    def test_get_model_enrollment_status_openai_proxy_fallback(self, service):
+        """Test status fallback to OpenAI-compatible models listing."""
+        model_id = "gpt-4o"
+        fallback_response = Mock()
+        fallback_response.text = "ok"
+        fallback_response.json.return_value = {
+            "data": [{"id": "gpt-4o"}, {"id": "gpt-4.1"}]
+        }
+
+        with patch.object(
+            service,
+            "_make_request",
+            side_effect=[
+                RuntimeError("not found"),
+                RuntimeError("not found"),
+                fallback_response,
+            ],
+        ) as mock_req:
+            result = service.get_model_enrollment_status(model_id)
+
+        assert result["model_rid"] == "gpt-4o"
+        assert result["status"] == "AVAILABLE"
+        assert result["type"] == "OPENAI"
+        assert mock_req.call_args_list[-1].args == (
+            "GET",
+            "/api/v2/llm/proxy/openai/v1/models",
+        )
+
+    def test_get_model_enrollment_status_not_found_after_fallback(self, service):
+        """Test error when model is not found in fallback list either."""
+        model_id = "missing-model"
+        fallback_response = Mock()
+        fallback_response.text = "ok"
+        fallback_response.json.return_value = {"data": [{"id": "gpt-4o"}]}
+
+        with patch.object(
+            service,
+            "_make_request",
+            side_effect=[
+                RuntimeError("not found"),
+                RuntimeError("not found"),
+                fallback_response,
+            ],
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                service.get_model_enrollment_status(model_id)
+
+        assert "not found via any known endpoint" in str(exc_info.value)
+
+    def test_get_model_enrollment_status_fallback_request_failure(self, service):
+        """Test error details when fallback endpoint request fails."""
+        model_id = "missing-model"
+
+        with patch.object(
+            service,
+            "_make_request",
+            side_effect=[
+                RuntimeError("primary endpoint down"),
+                RuntimeError("primary endpoint down"),
+                RuntimeError("fallback endpoint down"),
+            ],
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                service.get_model_enrollment_status(model_id)
+
+        error_text = str(exc_info.value)
+        assert "Primary endpoint error" in error_text
+        assert "Fallback endpoint error" in error_text
+
+    def test_get_model_enrollment_status_json_error_falls_back(self, service):
+        """Test JSON decode errors trigger fallback instead of opaque command errors."""
+        model_id = "gpt-4o"
+        bad_primary_response = Mock()
+        bad_primary_response.text = "not-json"
+        bad_primary_response.json.side_effect = ValueError("invalid json")
+
+        fallback_response = Mock()
+        fallback_response.text = "ok"
+        fallback_response.json.return_value = {"data": [{"id": "gpt-4o"}]}
+
+        with patch.object(
+            service,
+            "_make_request",
+            side_effect=[
+                bad_primary_response,
+                RuntimeError("not found"),
+                fallback_response,
+            ],
+        ):
+            result = service.get_model_enrollment_status(model_id)
+
+        assert result["model_rid"] == "gpt-4o"
+        assert result["status"] == "AVAILABLE"
+
+    def test_enroll_model_success(self, service):
+        """Test enrolling a language model."""
+        model_id = (
+            "ri.language-model-service..language-model.anthropic_claude_3_5_sonnet_v2"
+        )
+        mock_response = Mock()
+        mock_response.text = "ok"
+        mock_response.json.return_value = {
+            "status": "ENROLLED",
+            "provider": "ANTHROPIC",
+        }
+
+        with patch.object(
+            service, "_make_request", return_value=mock_response
+        ) as mock_req:
+            result = service.enroll_model(model_id)
+
+        assert result["model_rid"] == model_id
+        assert result["status"] == "ENROLLED"
+        assert result["type"] == "ANTHROPIC"
+        assert result["display_name"] == model_id
+        assert "response" not in result
+        mock_req.assert_called_once_with(
+            "POST",
+            "/v2/languageModels/ri.language-model-service..language-model.anthropic_claude_3_5_sonnet_v2/enroll",
+            json_data={},
+        )
+
+    def test_enroll_model_fallback_endpoint(self, service):
+        """Test enrollment fallback when the first endpoint fails."""
+        model_id = "ri.language-model-service..language-model.gpt_4o"
+        fallback_response = Mock()
+        fallback_response.text = "ok"
+        fallback_response.json.return_value = {"status": "ENROLLED"}
+
+        with patch.object(
+            service,
+            "_make_request",
+            side_effect=[RuntimeError("missing endpoint"), fallback_response],
+        ) as mock_req:
+            result = service.enroll_model(model_id)
+
+        assert result["model_rid"] == model_id
+        assert result["status"] == "ENROLLED"
+        assert mock_req.call_args_list[-1].args == (
+            "POST",
+            "/api/v2/llm/models/ri.language-model-service..language-model.gpt_4o/enroll",
+        )
+        assert mock_req.call_args_list[-1].kwargs == {"json_data": {}}
+
+    def test_enroll_model_error(self, service):
+        """Test enrollment error handling when all endpoints fail."""
+        with patch.object(
+            service, "_make_request", side_effect=RuntimeError("unavailable")
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                service.enroll_model(
+                    "ri.language-model-service..language-model.some_model"
+                )
+
+        assert "Failed to enroll model" in str(exc_info.value)
+        assert "Model Catalog UI access for this model" in str(exc_info.value)
+
     # ===== OpenAI Embeddings Tests =====
 
     def test_generate_embeddings_single_text(self, service, mock_client):

--- a/tests/test_services/test_language_models.py
+++ b/tests/test_services/test_language_models.py
@@ -1,5 +1,6 @@
 """Tests for LanguageModels service."""
 
+import json
 import pytest
 import requests
 from unittest.mock import Mock, patch
@@ -417,7 +418,7 @@ class TestLanguageModelsService:
             result = service.get_model_enrollment_status(model_id)
 
         assert result["model_rid"] == "gpt-4o"
-        assert result["status"] == "AVAILABLE"
+        assert result["status"] == "AVAILABLE_VIA_PROXY"
         assert result["type"] == "OPENAI"
         assert mock_req.call_args_list[-1].args == (
             "GET",
@@ -470,7 +471,9 @@ class TestLanguageModelsService:
         model_id = "gpt-4o"
         bad_primary_response = Mock()
         bad_primary_response.text = "not-json"
-        bad_primary_response.json.side_effect = ValueError("invalid json")
+        bad_primary_response.json.side_effect = json.JSONDecodeError(
+            "invalid json", "not-json", 0
+        )
 
         fallback_response = Mock()
         fallback_response.text = "ok"
@@ -488,7 +491,7 @@ class TestLanguageModelsService:
             result = service.get_model_enrollment_status(model_id)
 
         assert result["model_rid"] == "gpt-4o"
-        assert result["status"] == "AVAILABLE"
+        assert result["status"] == "AVAILABLE_VIA_PROXY"
 
     def test_enroll_model_success(self, service):
         """Test enrolling a language model."""
@@ -539,6 +542,7 @@ class TestLanguageModelsService:
             "/api/v2/llm/models/ri.language-model-service..language-model.gpt_4o/enroll",
         )
         assert mock_req.call_args_list[-1].kwargs == {"json_data": {}}
+        assert len(mock_req.call_args_list) == 2
 
     def test_enroll_model_error(self, service):
         """Test enrollment error handling when all endpoints fail."""


### PR DESCRIPTION
## Summary
- add new language-models status command to check model enrollment status
- add new language-models enroll command to request model enrollment for API usage
- add service methods with endpoint fallback and normalized response fields
- add command and service tests for success, fallback, and error handling

## Testing
- uv run pytest tests/test_services/test_language_models.py tests/test_commands/test_language_models.py
- uv run ruff check src/pltr/services/language_models.py src/pltr/commands/language_models.py tests/test_services/test_language_models.py tests/test_commands/test_language_models.py

Closes #165