### PR TITLE
Add ontology object-type/link-type create commands (issue #143)

### DIFF
--- a/src/pltr/commands/ontology.py
+++ b/src/pltr/commands/ontology.py
@@ -164,6 +164,112 @@ def get_object_type(
         raise typer.Exit(1)
 
 
+@app.command("object-type-create")
+def create_object_type(
+    ontology_rid: str = typer.Argument(..., help="Ontology Resource Identifier"),
+    api_name: str = typer.Option(..., "--api-name", help="Object type API name"),
+    display_name: str = typer.Option(
+        ..., "--display-name", help="Object type display name"
+    ),
+    primary_key: str = typer.Option(
+        ..., "--primary-key", help="Primary key property API name"
+    ),
+    backing_dataset: str = typer.Option(
+        ..., "--backing-dataset", help="Backing dataset RID"
+    ),
+    description: Optional[str] = typer.Option(
+        None, "--description", help="Object type description"
+    ),
+    profile: Optional[str] = typer.Option(None, "--profile", "-p", help="Profile name"),
+    format: str = typer.Option(
+        "table", "--format", "-f", help="Output format (table, json, csv)"
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+):
+    """Create a new object type in an ontology."""
+    try:
+        service = ObjectTypeService(profile=profile)
+
+        with SpinnerProgressTracker().track_spinner(
+            f"Creating object type {api_name}..."
+        ):
+            result = service.create_object_type(
+                ontology_rid=ontology_rid,
+                api_name=api_name,
+                display_name=display_name,
+                primary_key=primary_key,
+                backing_dataset=backing_dataset,
+                description=description,
+            )
+
+        formatter.format_dict(result, format=format, output=output)
+
+        if output:
+            formatter.print_success(f"Object type creation result saved to {output}")
+
+    except (ProfileNotFoundError, MissingCredentialsError) as e:
+        formatter.print_error(f"Authentication error: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        formatter.print_error(f"Failed to create object type: {e}")
+        raise typer.Exit(1)
+
+
+@app.command("link-type-create")
+def create_link_type(
+    ontology_rid: str = typer.Argument(..., help="Ontology Resource Identifier"),
+    api_name: str = typer.Option(..., "--api-name", help="Link type API name"),
+    from_object: str = typer.Option(
+        ..., "--from", help="Source object type API name"
+    ),
+    to_object: str = typer.Option(..., "--to", help="Target object type API name"),
+    display_name: Optional[str] = typer.Option(
+        None, "--display-name", help="Link type display name"
+    ),
+    description: Optional[str] = typer.Option(
+        None, "--description", help="Link type description"
+    ),
+    reverse_api_name: Optional[str] = typer.Option(
+        None, "--reverse-api-name", help="Reverse direction link type API name"
+    ),
+    profile: Optional[str] = typer.Option(None, "--profile", "-p", help="Profile name"),
+    format: str = typer.Option(
+        "table", "--format", "-f", help="Output format (table, json, csv)"
+    ),
+    output: Optional[str] = typer.Option(
+        None, "--output", "-o", help="Output file path"
+    ),
+):
+    """Create a new link type in an ontology."""
+    try:
+        service = ObjectTypeService(profile=profile)
+
+        with SpinnerProgressTracker().track_spinner(f"Creating link type {api_name}..."):
+            result = service.create_link_type(
+                ontology_rid=ontology_rid,
+                api_name=api_name,
+                from_object_type=from_object,
+                to_object_type=to_object,
+                display_name=display_name,
+                description=description,
+                reverse_api_name=reverse_api_name,
+            )
+
+        formatter.format_dict(result, format=format, output=output)
+
+        if output:
+            formatter.print_success(f"Link type creation result saved to {output}")
+
+    except (ProfileNotFoundError, MissingCredentialsError) as e:
+        formatter.print_error(f"Authentication error: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        formatter.print_error(f"Failed to create link type: {e}")
+        raise typer.Exit(1)
+
+
 # Object operations
 @app.command("object-list")
 def list_objects(

--- a/src/pltr/commands/ontology.py
+++ b/src/pltr/commands/ontology.py
@@ -221,9 +221,7 @@ def create_object_type(
 def create_link_type(
     ontology_rid: str = typer.Argument(..., help="Ontology Resource Identifier"),
     api_name: str = typer.Option(..., "--api-name", help="Link type API name"),
-    from_object: str = typer.Option(
-        ..., "--from", help="Source object type API name"
-    ),
+    from_object: str = typer.Option(..., "--from", help="Source object type API name"),
     to_object: str = typer.Option(..., "--to", help="Target object type API name"),
     display_name: Optional[str] = typer.Option(
         None, "--display-name", help="Link type display name"
@@ -246,7 +244,9 @@ def create_link_type(
     try:
         service = ObjectTypeService(profile=profile)
 
-        with SpinnerProgressTracker().track_spinner(f"Creating link type {api_name}..."):
+        with SpinnerProgressTracker().track_spinner(
+            f"Creating link type {api_name}..."
+        ):
             result = service.create_link_type(
                 ontology_rid=ontology_rid,
                 api_name=api_name,

--- a/src/pltr/services/ontology.py
+++ b/src/pltr/services/ontology.py
@@ -3,6 +3,7 @@ Ontology service wrappers for Foundry SDK.
 """
 
 from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import quote
 
 from ..config.settings import Settings
 from ..utils.pagination import PaginationConfig, PaginationResult
@@ -62,6 +63,17 @@ class OntologyService(BaseService):
 class ObjectTypeService(BaseService):
     """Service wrapper for object type operations."""
 
+    _OBJECT_TYPE_CREATE_ENDPOINTS = [
+        "/v2/ontologies/{ontology}/objectTypes",
+        "/v1/ontologies/{ontology}/objectTypes",
+        "/ontology-manager/api/ontologies/{ontology}/objectTypes",
+    ]
+    _LINK_TYPE_CREATE_ENDPOINTS = [
+        "/v2/ontologies/{ontology}/linkTypes",
+        "/v1/ontologies/{ontology}/linkTypes",
+        "/ontology-manager/api/ontologies/{ontology}/linkTypes",
+    ]
+
     def _get_service(self) -> Any:
         """Get the Foundry ontologies service."""
         return self.client.ontologies
@@ -104,6 +116,95 @@ class ObjectTypeService(BaseService):
             return self._format_object_type_info(obj_type)
         except Exception as e:
             raise RuntimeError(f"Failed to get object type {object_type}: {e}")
+
+    def create_object_type(
+        self,
+        ontology_rid: str,
+        api_name: str,
+        display_name: str,
+        primary_key: str,
+        backing_dataset: str,
+        description: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Create an ontology object type via direct API calls.
+
+        Args:
+            ontology_rid: Ontology Resource Identifier
+            api_name: Object type API name
+            display_name: Object type display name
+            primary_key: Primary key property API name
+            backing_dataset: Backing dataset RID
+            description: Optional object type description
+
+        Returns:
+            API response dictionary
+        """
+        payload = {
+            "apiName": api_name,
+            "displayName": display_name,
+            "primaryKey": primary_key,
+            "backingDatasetRid": backing_dataset,
+        }
+        if description:
+            payload["description"] = description
+
+        return self._create_schema_entity(
+            ontology_rid=ontology_rid,
+            endpoints=self._OBJECT_TYPE_CREATE_ENDPOINTS,
+            payload=payload,
+            entity_type="object type",
+            entity_id=api_name,
+        )
+
+    def create_link_type(
+        self,
+        ontology_rid: str,
+        api_name: str,
+        from_object_type: str,
+        to_object_type: str,
+        display_name: Optional[str] = None,
+        description: Optional[str] = None,
+        reverse_api_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Create an ontology link type via direct API calls.
+
+        Args:
+            ontology_rid: Ontology Resource Identifier
+            api_name: Link type API name
+            from_object_type: Source object type API name
+            to_object_type: Target object type API name
+            display_name: Optional link type display name
+            description: Optional link type description
+            reverse_api_name: Optional reverse direction API name
+
+        Returns:
+            API response dictionary
+        """
+        payload = {
+            "apiName": api_name,
+            "fromObjectTypeApiName": from_object_type,
+            "toObjectTypeApiName": to_object_type,
+            "linkTypeApiNameAtoB": api_name,
+            "aSideObjectTypeApiName": from_object_type,
+            "bSideObjectTypeApiName": to_object_type,
+        }
+        if display_name:
+            payload["displayName"] = display_name
+        if description:
+            payload["description"] = description
+        if reverse_api_name:
+            payload["linkTypeApiNameBtoA"] = reverse_api_name
+            payload["reverseApiName"] = reverse_api_name
+
+        return self._create_schema_entity(
+            ontology_rid=ontology_rid,
+            endpoints=self._LINK_TYPE_CREATE_ENDPOINTS,
+            payload=payload,
+            entity_type="link type",
+            entity_id=api_name,
+        )
 
     def list_outgoing_link_types(
         self, ontology_rid: str, object_type: str
@@ -149,6 +250,37 @@ class ObjectTypeService(BaseService):
             "object_type": getattr(link_type, "object_type", None),
             "linked_object_type": getattr(link_type, "linked_object_type", None),
         }
+
+    def _create_schema_entity(
+        self,
+        ontology_rid: str,
+        endpoints: List[str],
+        payload: Dict[str, Any],
+        entity_type: str,
+        entity_id: str,
+    ) -> Dict[str, Any]:
+        """Post create requests across known schema management endpoints."""
+        encoded_ontology = quote(ontology_rid, safe="")
+        last_error: Optional[Exception] = None
+
+        for endpoint_template in endpoints:
+            endpoint = endpoint_template.format(ontology=encoded_ontology)
+            try:
+                response = self._make_request("POST", endpoint, json_data=payload)
+                result = response.json() if response.text else {}
+                if isinstance(result, dict):
+                    result.setdefault("apiName", entity_id)
+                    result.setdefault("ontologyRid", ontology_rid)
+                    return result
+                return {
+                    "apiName": entity_id,
+                    "ontologyRid": ontology_rid,
+                    "response": result,
+                }
+            except Exception as e:
+                last_error = e
+
+        raise RuntimeError(f"Failed to create {entity_type} {entity_id}: {last_error}")
 
 
 class OntologyObjectService(BaseService):

--- a/src/pltr/services/ontology.py
+++ b/src/pltr/services/ontology.py
@@ -2,8 +2,9 @@
 Ontology service wrappers for Foundry SDK.
 """
 
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import quote
+import requests
 
 from ..config.settings import Settings
 from ..utils.pagination import PaginationConfig, PaginationResult
@@ -146,7 +147,7 @@ class ObjectTypeService(BaseService):
             "primaryKey": primary_key,
             "backingDatasetRid": backing_dataset,
         }
-        if description:
+        if description is not None:
             payload["description"] = description
 
         return self._create_schema_entity(
@@ -182,26 +183,37 @@ class ObjectTypeService(BaseService):
         Returns:
             API response dictionary
         """
-        payload = {
+        modern_payload = {
             "apiName": api_name,
             "fromObjectTypeApiName": from_object_type,
             "toObjectTypeApiName": to_object_type,
+        }
+        legacy_payload = {
+            "apiName": api_name,
             "linkTypeApiNameAtoB": api_name,
             "aSideObjectTypeApiName": from_object_type,
             "bSideObjectTypeApiName": to_object_type,
         }
-        if display_name:
-            payload["displayName"] = display_name
-        if description:
-            payload["description"] = description
-        if reverse_api_name:
-            payload["linkTypeApiNameBtoA"] = reverse_api_name
-            payload["reverseApiName"] = reverse_api_name
+
+        if display_name is not None:
+            modern_payload["displayName"] = display_name
+            legacy_payload["displayName"] = display_name
+        if description is not None:
+            modern_payload["description"] = description
+            legacy_payload["description"] = description
+        if reverse_api_name is not None:
+            modern_payload["reverseApiName"] = reverse_api_name
+            legacy_payload["linkTypeApiNameBtoA"] = reverse_api_name
+
+        def payload_for_endpoint(endpoint_template: str) -> Dict[str, Any]:
+            if endpoint_template.startswith("/v2/"):
+                return modern_payload
+            return legacy_payload
 
         return self._create_schema_entity(
             ontology_rid=ontology_rid,
             endpoints=self._LINK_TYPE_CREATE_ENDPOINTS,
-            payload=payload,
+            payload=payload_for_endpoint,
             entity_type="link type",
             entity_id=api_name,
         )
@@ -255,7 +267,7 @@ class ObjectTypeService(BaseService):
         self,
         ontology_rid: str,
         endpoints: List[str],
-        payload: Dict[str, Any],
+        payload: Union[Dict[str, Any], Callable[[str], Dict[str, Any]]],
         entity_type: str,
         entity_id: str,
     ) -> Dict[str, Any]:
@@ -265,8 +277,13 @@ class ObjectTypeService(BaseService):
 
         for endpoint_template in endpoints:
             endpoint = endpoint_template.format(ontology=encoded_ontology)
+            request_payload = (
+                payload(endpoint_template) if callable(payload) else payload
+            )
             try:
-                response = self._make_request("POST", endpoint, json_data=payload)
+                response = self._make_request(
+                    "POST", endpoint, json_data=request_payload
+                )
                 result = response.json() if response.text else {}
                 if isinstance(result, dict):
                     result.setdefault("apiName", entity_id)
@@ -277,8 +294,28 @@ class ObjectTypeService(BaseService):
                     "ontologyRid": ontology_rid,
                     "response": result,
                 }
-            except Exception as e:
+            except requests.HTTPError as e:
+                status_code = e.response.status_code if e.response is not None else None
+                if status_code not in (404, 405):
+                    raise RuntimeError(
+                        f"Failed to create {entity_type} {entity_id}: {e}"
+                    ) from e
                 last_error = e
+            except RuntimeError as e:
+                if "404" in str(e) or "405" in str(e):
+                    last_error = e
+                    continue
+                raise RuntimeError(f"Failed to create {entity_type} {entity_id}: {e}")
+            except requests.RequestException as e:
+                raise RuntimeError(f"Failed to create {entity_type} {entity_id}: {e}")
+            except ValueError as e:
+                raise RuntimeError(
+                    f"Failed to parse create {entity_type} response for {entity_id}: {e}"
+                ) from e
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to create {entity_type} {entity_id}: {e}"
+                ) from e
 
         raise RuntimeError(f"Failed to create {entity_type} {entity_id}: {last_error}")
 

--- a/tests/test_commands/test_ontology.py
+++ b/tests/test_commands/test_ontology.py
@@ -136,6 +136,7 @@ def test_create_object_type_command(mock_services):
     )
 
     assert result.exit_code == 0
+    assert "TMAircraft" in result.output
     mock_instance.create_object_type.assert_called_once_with(
         ontology_rid="ri.ontology.main.ontology.test",
         api_name="TMAircraft",
@@ -144,6 +145,62 @@ def test_create_object_type_command(mock_services):
         backing_dataset="ri.foundry.main.dataset.aircraft",
         description=None,
     )
+
+
+def test_create_object_type_command_auth_error(mock_services):
+    """Test object type create command auth error handling."""
+    from pltr.auth.base import ProfileNotFoundError
+
+    mock_instance = Mock()
+    mock_instance.create_object_type.side_effect = ProfileNotFoundError(
+        "Profile not found"
+    )
+    mock_services["object_type"].return_value = mock_instance
+
+    result = runner.invoke(
+        app,
+        [
+            "object-type-create",
+            "ri.ontology.main.ontology.test",
+            "--api-name",
+            "TMAircraft",
+            "--display-name",
+            "TM Aircraft",
+            "--primary-key",
+            "msn",
+            "--backing-dataset",
+            "ri.foundry.main.dataset.aircraft",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Authentication error" in result.output
+
+
+def test_create_object_type_command_runtime_error(mock_services):
+    """Test object type create command runtime error handling."""
+    mock_instance = Mock()
+    mock_instance.create_object_type.side_effect = RuntimeError("boom")
+    mock_services["object_type"].return_value = mock_instance
+
+    result = runner.invoke(
+        app,
+        [
+            "object-type-create",
+            "ri.ontology.main.ontology.test",
+            "--api-name",
+            "TMAircraft",
+            "--display-name",
+            "TM Aircraft",
+            "--primary-key",
+            "msn",
+            "--backing-dataset",
+            "ri.foundry.main.dataset.aircraft",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Failed to create object type" in result.output
 
 
 def test_create_link_type_command(mock_services):
@@ -172,6 +229,7 @@ def test_create_link_type_command(mock_services):
     )
 
     assert result.exit_code == 0
+    assert "aircraftLease" in result.output
     mock_instance.create_link_type.assert_called_once_with(
         ontology_rid="ri.ontology.main.ontology.test",
         api_name="aircraftLease",
@@ -181,6 +239,58 @@ def test_create_link_type_command(mock_services):
         description=None,
         reverse_api_name="leaseAircraft",
     )
+
+
+def test_create_link_type_command_auth_error(mock_services):
+    """Test link type create command auth error handling."""
+    from pltr.auth.base import MissingCredentialsError
+
+    mock_instance = Mock()
+    mock_instance.create_link_type.side_effect = MissingCredentialsError(
+        "Missing credentials"
+    )
+    mock_services["object_type"].return_value = mock_instance
+
+    result = runner.invoke(
+        app,
+        [
+            "link-type-create",
+            "ri.ontology.main.ontology.test",
+            "--api-name",
+            "aircraftLease",
+            "--from",
+            "TMAircraft",
+            "--to",
+            "TMLeaseAgreement",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Authentication error" in result.output
+
+
+def test_create_link_type_command_runtime_error(mock_services):
+    """Test link type create command runtime error handling."""
+    mock_instance = Mock()
+    mock_instance.create_link_type.side_effect = RuntimeError("boom")
+    mock_services["object_type"].return_value = mock_instance
+
+    result = runner.invoke(
+        app,
+        [
+            "link-type-create",
+            "ri.ontology.main.ontology.test",
+            "--api-name",
+            "aircraftLease",
+            "--from",
+            "TMAircraft",
+            "--to",
+            "TMLeaseAgreement",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Failed to create link type" in result.output
 
 
 # Object operation command tests

--- a/tests/test_commands/test_ontology.py
+++ b/tests/test_commands/test_ontology.py
@@ -110,6 +110,79 @@ def test_get_object_type_command(mock_services):
     )
 
 
+def test_create_object_type_command(mock_services):
+    """Test create object type command."""
+    mock_instance = Mock()
+    mock_instance.create_object_type.return_value = {
+        "apiName": "TMAircraft",
+        "ontologyRid": "ri.ontology.main.ontology.test",
+    }
+    mock_services["object_type"].return_value = mock_instance
+
+    result = runner.invoke(
+        app,
+        [
+            "object-type-create",
+            "ri.ontology.main.ontology.test",
+            "--api-name",
+            "TMAircraft",
+            "--display-name",
+            "TM Aircraft",
+            "--primary-key",
+            "msn",
+            "--backing-dataset",
+            "ri.foundry.main.dataset.aircraft",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_instance.create_object_type.assert_called_once_with(
+        ontology_rid="ri.ontology.main.ontology.test",
+        api_name="TMAircraft",
+        display_name="TM Aircraft",
+        primary_key="msn",
+        backing_dataset="ri.foundry.main.dataset.aircraft",
+        description=None,
+    )
+
+
+def test_create_link_type_command(mock_services):
+    """Test create link type command."""
+    mock_instance = Mock()
+    mock_instance.create_link_type.return_value = {
+        "apiName": "aircraftLease",
+        "ontologyRid": "ri.ontology.main.ontology.test",
+    }
+    mock_services["object_type"].return_value = mock_instance
+
+    result = runner.invoke(
+        app,
+        [
+            "link-type-create",
+            "ri.ontology.main.ontology.test",
+            "--api-name",
+            "aircraftLease",
+            "--from",
+            "TMAircraft",
+            "--to",
+            "TMLeaseAgreement",
+            "--reverse-api-name",
+            "leaseAircraft",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_instance.create_link_type.assert_called_once_with(
+        ontology_rid="ri.ontology.main.ontology.test",
+        api_name="aircraftLease",
+        from_object_type="TMAircraft",
+        to_object_type="TMLeaseAgreement",
+        display_name=None,
+        description=None,
+        reverse_api_name="leaseAircraft",
+    )
+
+
 # Object operation command tests
 def test_list_objects_command(mock_services):
     """Test list objects command."""

--- a/tests/test_services/test_ontology.py
+++ b/tests/test_services/test_ontology.py
@@ -3,6 +3,7 @@ Tests for ontology services.
 """
 
 import pytest
+import requests
 from unittest.mock import Mock, patch
 
 from pltr.services.ontology import (
@@ -12,6 +13,13 @@ from pltr.services.ontology import (
     ActionService,
     QueryService,
 )
+
+
+def _http_error(status_code: int, message: str) -> requests.HTTPError:
+    """Create an HTTPError with an attached response status code."""
+    error = requests.HTTPError(message)
+    error.response = Mock(status_code=status_code)
+    return error
 
 
 @pytest.fixture
@@ -282,6 +290,27 @@ def test_create_object_type(mock_object_type_service):
     )
 
 
+def test_create_object_type_with_description(mock_object_type_service):
+    """Test creating an object type includes description when provided."""
+    service, _ = mock_object_type_service
+
+    mock_response = Mock()
+    mock_response.text = "ok"
+    mock_response.json.return_value = {"apiName": "TMAircraft"}
+
+    with patch.object(service, "_make_request", return_value=mock_response) as mock_req:
+        service.create_object_type(
+            ontology_rid="ri.ontology.main.ontology.test",
+            api_name="TMAircraft",
+            display_name="TM Aircraft",
+            primary_key="msn",
+            backing_dataset="ri.foundry.main.dataset.aircraft",
+            description="Aircraft entity",
+        )
+
+    assert mock_req.call_args.kwargs["json_data"]["description"] == "Aircraft entity"
+
+
 def test_create_link_type(mock_object_type_service):
     """Test creating a link type via direct API endpoint."""
     service, _ = mock_object_type_service
@@ -311,10 +340,6 @@ def test_create_link_type(mock_object_type_service):
             "apiName": "aircraftLease",
             "fromObjectTypeApiName": "TMAircraft",
             "toObjectTypeApiName": "TMLeaseAgreement",
-            "linkTypeApiNameAtoB": "aircraftLease",
-            "aSideObjectTypeApiName": "TMAircraft",
-            "bSideObjectTypeApiName": "TMLeaseAgreement",
-            "linkTypeApiNameBtoA": "leaseAircraft",
             "reverseApiName": "leaseAircraft",
         },
     )
@@ -328,7 +353,9 @@ def test_create_object_type_fallback_endpoint(mock_object_type_service):
     mock_response.text = ""
 
     with patch.object(
-        service, "_make_request", side_effect=[RuntimeError("404"), mock_response]
+        service,
+        "_make_request",
+        side_effect=[_http_error(404, "not found"), mock_response],
     ) as mock_req:
         result = service.create_object_type(
             ontology_rid="ri.ontology.main.ontology.test",
@@ -341,6 +368,79 @@ def test_create_object_type_fallback_endpoint(mock_object_type_service):
     assert result["apiName"] == "TMAircraft"
     assert result["ontologyRid"] == "ri.ontology.main.ontology.test"
     assert mock_req.call_count == 2
+
+
+def test_create_object_type_non_404_does_not_fallback(mock_object_type_service):
+    """Test non-404 errors fail immediately instead of trying all endpoints."""
+    service, _ = mock_object_type_service
+
+    with patch.object(
+        service, "_make_request", side_effect=_http_error(403, "forbidden")
+    ) as mock_req:
+        with pytest.raises(
+            RuntimeError, match="Failed to create object type TMAircraft"
+        ):
+            service.create_object_type(
+                ontology_rid="ri.ontology.main.ontology.test",
+                api_name="TMAircraft",
+                display_name="TM Aircraft",
+                primary_key="msn",
+                backing_dataset="ri.foundry.main.dataset.aircraft",
+            )
+
+    assert mock_req.call_count == 1
+
+
+def test_create_object_type_all_endpoints_fail(mock_object_type_service):
+    """Test object type creation failure after exhausting fallback endpoints."""
+    service, _ = mock_object_type_service
+
+    with patch.object(
+        service,
+        "_make_request",
+        side_effect=[
+            _http_error(404, "not found"),
+            _http_error(404, "not found"),
+            _http_error(404, "not found"),
+        ],
+    ):
+        with pytest.raises(
+            RuntimeError, match="Failed to create object type TMAircraft"
+        ):
+            service.create_object_type(
+                ontology_rid="ri.ontology.main.ontology.test",
+                api_name="TMAircraft",
+                display_name="TM Aircraft",
+                primary_key="msn",
+                backing_dataset="ri.foundry.main.dataset.aircraft",
+            )
+
+
+def test_create_link_type_fallback_uses_legacy_payload(mock_object_type_service):
+    """Test link type fallback uses legacy payload fields for legacy endpoints."""
+    service, _ = mock_object_type_service
+
+    mock_response = Mock()
+    mock_response.text = "ok"
+    mock_response.json.return_value = {"apiName": "aircraftLease"}
+
+    with patch.object(
+        service,
+        "_make_request",
+        side_effect=[_http_error(404, "not found"), mock_response],
+    ) as mock_req:
+        service.create_link_type(
+            ontology_rid="ri.ontology.main.ontology.test",
+            api_name="aircraftLease",
+            from_object_type="TMAircraft",
+            to_object_type="TMLeaseAgreement",
+            reverse_api_name="leaseAircraft",
+        )
+
+    fallback_payload = mock_req.call_args_list[-1].kwargs["json_data"]
+    assert "linkTypeApiNameAtoB" in fallback_payload
+    assert "aSideObjectTypeApiName" in fallback_payload
+    assert "fromObjectTypeApiName" not in fallback_payload
 
 
 # OntologyObjectService Tests

--- a/tests/test_services/test_ontology.py
+++ b/tests/test_services/test_ontology.py
@@ -248,6 +248,101 @@ def test_get_object_type(mock_object_type_service, sample_object_type):
     )
 
 
+def test_create_object_type(mock_object_type_service):
+    """Test creating an object type via direct API endpoint."""
+    service, _ = mock_object_type_service
+
+    mock_response = Mock()
+    mock_response.text = "ok"
+    mock_response.json.return_value = {
+        "apiName": "TMAircraft",
+        "ontologyRid": "ri.ontology.main.ontology.test",
+    }
+
+    with patch.object(service, "_make_request", return_value=mock_response) as mock_req:
+        result = service.create_object_type(
+            ontology_rid="ri.ontology.main.ontology.test",
+            api_name="TMAircraft",
+            display_name="TM Aircraft",
+            primary_key="msn",
+            backing_dataset="ri.foundry.main.dataset.aircraft",
+        )
+
+    assert result["apiName"] == "TMAircraft"
+    assert result["ontologyRid"] == "ri.ontology.main.ontology.test"
+    mock_req.assert_called_once_with(
+        "POST",
+        "/v2/ontologies/ri.ontology.main.ontology.test/objectTypes",
+        json_data={
+            "apiName": "TMAircraft",
+            "displayName": "TM Aircraft",
+            "primaryKey": "msn",
+            "backingDatasetRid": "ri.foundry.main.dataset.aircraft",
+        },
+    )
+
+
+def test_create_link_type(mock_object_type_service):
+    """Test creating a link type via direct API endpoint."""
+    service, _ = mock_object_type_service
+
+    mock_response = Mock()
+    mock_response.text = "ok"
+    mock_response.json.return_value = {
+        "apiName": "aircraftLease",
+        "ontologyRid": "ri.ontology.main.ontology.test",
+    }
+
+    with patch.object(service, "_make_request", return_value=mock_response) as mock_req:
+        result = service.create_link_type(
+            ontology_rid="ri.ontology.main.ontology.test",
+            api_name="aircraftLease",
+            from_object_type="TMAircraft",
+            to_object_type="TMLeaseAgreement",
+            reverse_api_name="leaseAircraft",
+        )
+
+    assert result["apiName"] == "aircraftLease"
+    assert result["ontologyRid"] == "ri.ontology.main.ontology.test"
+    mock_req.assert_called_once_with(
+        "POST",
+        "/v2/ontologies/ri.ontology.main.ontology.test/linkTypes",
+        json_data={
+            "apiName": "aircraftLease",
+            "fromObjectTypeApiName": "TMAircraft",
+            "toObjectTypeApiName": "TMLeaseAgreement",
+            "linkTypeApiNameAtoB": "aircraftLease",
+            "aSideObjectTypeApiName": "TMAircraft",
+            "bSideObjectTypeApiName": "TMLeaseAgreement",
+            "linkTypeApiNameBtoA": "leaseAircraft",
+            "reverseApiName": "leaseAircraft",
+        },
+    )
+
+
+def test_create_object_type_fallback_endpoint(mock_object_type_service):
+    """Test object type creation fallback across endpoint variants."""
+    service, _ = mock_object_type_service
+
+    mock_response = Mock()
+    mock_response.text = ""
+
+    with patch.object(
+        service, "_make_request", side_effect=[RuntimeError("404"), mock_response]
+    ) as mock_req:
+        result = service.create_object_type(
+            ontology_rid="ri.ontology.main.ontology.test",
+            api_name="TMAircraft",
+            display_name="TM Aircraft",
+            primary_key="msn",
+            backing_dataset="ri.foundry.main.dataset.aircraft",
+        )
+
+    assert result["apiName"] == "TMAircraft"
+    assert result["ontologyRid"] == "ri.ontology.main.ontology.test"
+    assert mock_req.call_count == 2
+
+
 # OntologyObjectService Tests
 def test_list_objects(mock_ontology_object_service, sample_object):
     """Test listing objects."""


### PR DESCRIPTION
## Summary
- add new ontology object-type-create command with required schema fields
- add new ontology link-type-create command with from/to object types and optional reverse name
- add ObjectTypeService methods for schema creation using direct API calls with endpoint fallback
- add command and service tests for success paths and endpoint fallback

## Testing
- uv run pytest tests/test_services/test_ontology.py tests/test_commands/test_ontology.py
- uv run ruff check src/pltr/services/ontology.py src/pltr/commands/ontology.py tests/test_services/test_ontology.py tests/test_commands/test_ontology.py

Closes #143